### PR TITLE
feat(E01S01): Fix ruff I001 import ordering in pinocchio matlab_importer.py

### DIFF
--- a/.gaai/project/contexts/artefacts/delivery/E01S01.micro-delivery-report.md
+++ b/.gaai/project/contexts/artefacts/delivery/E01S01.micro-delivery-report.md
@@ -1,0 +1,72 @@
+---
+type: micro-delivery-report
+id: E01S01
+story: E01S01 — Fix ruff I001 import ordering in pinocchio matlab_importer.py
+agent: SUB-AGENT-MICRO-DELIVERY-001
+verdict: PASS
+completed_at: 2026-03-19
+---
+
+# E01S01 — Micro-Delivery Report
+
+## Summary
+
+The target file `src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py`
+was audited and found to already satisfy all acceptance criteria. Import ordering is correctly
+structured: `from __future__ import annotations` → stdlib → third-party → first-party.
+
+No code changes were required. The ruff I001 violation was resolved in a prior refactor commit
+(`a9ab8a12`). This delivery verifies, documents, and closes the story.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py` | No change required — already compliant |
+
+---
+
+## Acceptance Criteria Results
+
+| # | Criterion | Result |
+|---|-----------|--------|
+| AC1 | Imports sorted: stdlib → third-party → first-party | PASS |
+| AC2 | `ruff check` exits 0, no I001 errors | PASS |
+| AC3 | `ruff format` passes | PASS |
+| AC4 | No functional changes — import reordering only | PASS |
+| AC5 | All existing tests for this module continue to pass | PASS (1 test skipped — optional dep `dtack` not installed; same behavior as baseline) |
+
+---
+
+## QA Verification Commands
+
+```
+$ python3 -m ruff check src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py
+All checks passed!
+
+$ python3 -m ruff check --select I001 src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py
+All checks passed!
+
+$ python3 -m ruff format --check src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py
+1 file already formatted
+
+$ python3 -m ruff check src scripts tests
+All checks passed!
+
+$ python3 -m pytest tests/unit/engines/pinocchio/dtack/utils/test_matlab_importer.py -v
+1 skipped (dtack optional dependency not installed — expected)
+```
+
+---
+
+## Verdict
+
+**PASS** — All 5 acceptance criteria satisfied. No code changes were needed. Story E01S01 is complete.
+
+---
+
+## Remediation Log
+
+None — smooth delivery, 0 remediation cycles.


### PR DESCRIPTION
## Summary

- Verifies and closes E01S01: ruff I001 import ordering fix for `src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py`
- File already compliant: `from __future__ import annotations` → stdlib → third-party → first-party ordering is correct
- All 5 acceptance criteria pass: ruff check exits 0, ruff format passes, no functional changes, tests unaffected

## Test Results

- ruff check (full: src scripts tests): All checks passed!
- ruff format --check: 1 file already formatted
- Test suite: 1 skipped (dtack optional dep not installed — same baseline behavior)
- QA Verdict: PASS

## Changes Delivered

| File | Purpose |
|------|---------|
| `src/engines/physics_engines/pinocchio/python/dtack/utils/matlab_importer.py` | No change required — already compliant with I001 |
| `.gaai/project/contexts/artefacts/delivery/E01S01.micro-delivery-report.md` | Delivery audit trail |

## Story

- ID: E01S01
- Artefact: .gaai/project/contexts/artefacts/stories/E01S01.story.md
- GitHub Issue: #1960

🤖 Generated with [GAAI Delivery Agent](https://github.com/Fr-e-d/GAAI-framework)