### PR TITLE
docs: add Jules-only issue orchestration plan

### DIFF
--- a/.github/jules/policy.example.yml
+++ b/.github/jules/policy.example.yml
@@ -1,0 +1,63 @@
+# Jules orchestration policy example
+#
+# This file is documentation-first for now. It defines the shape of the
+# version-controlled policy layer proposed in the orchestration plan.
+
+enabled: true
+paused: false
+
+limits:
+  max_parallel_issues: 3
+  max_pr_repair_attempts: 3
+  repair_cooldown_minutes: 30
+
+dispatch:
+  require_ready_label: true
+  ready_label: "jules:ready"
+  blocked_label: "jules:blocked"
+  needs_human_label: "jules:needs-human"
+
+triggers:
+  issue_events:
+    - opened
+    - labeled
+    - reopened
+  pr_comment_commands:
+    - "/jules-fix-ci"
+    - "/jules-address-comments"
+  issue_comment_commands:
+    - "/jules-run"
+    - "/jules-retry"
+    - "/jules-status"
+  schedules:
+    queue_sweep: "*/30 * * * *"
+    pr_shepherd: "15 */2 * * *"
+    overnight_batch: "0 8 * * 1,4"
+
+validation_profiles:
+  docs:
+    - "markdown checks"
+    - "path sanity"
+  cleanup:
+    - "formatter"
+    - "linter"
+    - "targeted tests"
+  risky:
+    - "formatter"
+    - "linter"
+    - "type checks"
+    - "targeted tests"
+
+task_classes:
+  docs:
+    parallel: allowed
+    validation: docs
+  review-fix:
+    parallel: allowed
+    validation: cleanup
+  ci-repair:
+    parallel: exclusive
+    validation: cleanup
+  feature:
+    parallel: exclusive
+    validation: risky

--- a/docs/plans/JULES_ONLY_GITHUB_ISSUE_ORCHESTRATION_PLAN_2026-03-19.md
+++ b/docs/plans/JULES_ONLY_GITHUB_ISSUE_ORCHESTRATION_PLAN_2026-03-19.md
@@ -1,0 +1,664 @@
+# Jules-Only GitHub Issue Orchestration Plan
+
+Date: 2026-03-19
+
+## Purpose
+
+This document proposes a GitHub-native, Jules-only automation architecture for tackling repository work through GitHub Issues, GitHub Actions, branches, and pull requests.
+
+The design goal is to:
+
+- avoid dependence on local resources
+- keep orchestration durable and visible in GitHub
+- allow safe parallel agent work
+- reduce branch and PR chaos
+- keep the codebase clean while automation scales
+
+This plan assumes Jules is the sole execution backend for autonomous code work in the initial rollout.
+
+## Why a Jules-Only First Architecture Makes Sense
+
+For this repository, a Jules-only first phase is the cleanest path to operational stability.
+
+### Advantages
+
+- cloud-based execution avoids local machine bottlenecks
+- issue and PR automation already exists in this repo
+- GitHub becomes the natural source of truth
+- there is no need to solve multi-backend routing before the task model is stable
+- existing workflows already demonstrate viable patterns for queueing, repair, and PR management
+
+### Tradeoff
+
+This is not the most flexible long-term architecture, but it is likely the fastest route to a reliable autonomous workflow.
+
+The right strategy is:
+
+- standardize Jules-first orchestration now
+- keep the architecture backend-aware in naming and policy
+- add other backends later only after the GitHub task contract is stable
+
+## Existing Patterns To Build On
+
+The repository already contains the foundations of a Jules-only control plane:
+
+- `Jules-Control-Tower` routes events to worker workflows
+- `Jules-Issue-Resolver` gathers priority issues and launches code-fix sessions
+- `Jules-Hotfix-Creator` responds to CI failure on important branches
+- `PR-Comment-Responder` queues review comments instead of creating workflow cascades
+- `Jules-Comment-Processor` processes queued comments in batches
+- `Jules-PR-Compiler` consolidates multiple PRs into a cleaner review surface
+- `Jules-Auto-Assign-Issues` already uses issue labels and comments to bring Jules in
+
+These workflows suggest the right core ideas:
+
+- event routing should be centralized
+- noisy work should be queued and batched
+- agent work should be bounded by branch and task scope
+- there should be explicit safeguards against loops and duplicate work
+- cleanup and consolidation should be first-class concerns
+
+## Architectural Objective
+
+Create a Jules operating system for GitHub Issues with these properties:
+
+1. every automated task starts from or maps to a GitHub Issue
+2. every issue has explicit machine-readable routing metadata
+3. every Jules run is auditable through issue comments, workflow runs, labels, and PR links
+4. parallel work is allowed only when branch ownership and task boundaries are clear
+5. PR sprawl is actively managed through compilation, reuse, and cleanup
+6. automation can run continuously without making the repository messy
+
+## Source of Truth
+
+The recommended source-of-truth model is:
+
+- GitHub Issues: work authorization and durable state
+- GitHub Labels: routing, status, and policy signals
+- GitHub Actions: scheduler, router, and dispatcher
+- Pull Requests: change delivery
+- `.jules/` checked-in artifacts: queueing, grouping, and intermediate orchestration state where needed
+
+This plan does not require a local backlog manager for autonomous execution.
+
+## Recommended Issue Model
+
+Every issue intended for Jules automation should have a structured contract.
+
+### Required fields
+
+- objective
+- scope
+- acceptance criteria
+- risk level
+- task class
+- allowed file or directory scope if bounded
+- validation commands
+- merge strategy
+
+### Recommended issue sections
+
+- `Objective`
+- `Why This Matters`
+- `Scope`
+- `Out of Scope`
+- `Acceptance Criteria`
+- `Validation`
+- `Risk Level`
+- `Suggested Task Class`
+- `Notes For Jules`
+
+### Suggested task classes
+
+- `issue:triage`
+- `issue:ci-repair`
+- `issue:docs`
+- `issue:review-followup`
+- `issue:refactor`
+- `issue:test-generation`
+- `issue:cleanup`
+- `issue:feature`
+
+The task class should drive both prompt shape and branch policy.
+
+## Recommended Label Taxonomy
+
+The current repo already uses labels informally in several workflows. The next step is to normalize them.
+
+### Dispatch labels
+
+- `jules:ready`
+- `jules:queued`
+- `jules:assigned`
+- `jules:blocked`
+- `jules:needs-human`
+- `jules:done`
+
+### Task-class labels
+
+- `jules:triage`
+- `jules:ci-repair`
+- `jules:docs`
+- `jules:review-fix`
+- `jules:refactor`
+- `jules:test-gen`
+- `jules:cleanup`
+- `jules:feature`
+
+### Risk labels
+
+- `risk:low`
+- `risk:medium`
+- `risk:high`
+
+### Parallelism labels
+
+- `parallel:allowed`
+- `parallel:exclusive`
+
+### Queue hygiene labels
+
+- `queue:batched`
+- `queue:deduplicated`
+- `queue:superseded`
+
+## Proposed Jules Workflow Topology
+
+The repository currently has many Jules workflows. The medium-term design should consolidate them into a more regular topology.
+
+### 1. One control tower
+
+Use one top-level orchestrator as the only general router.
+
+Recommended responsibilities:
+
+- listen for issue events, PR events, workflow failures, schedules, and manual dispatch
+- classify work items
+- prevent duplicate dispatch
+- assign work to the correct worker family
+- enforce loop protection and retry limits
+
+This should evolve from the current `Jules-Control-Tower`.
+
+### 2. Worker families
+
+Replace the long list of one-off specialist workflows over time with reusable worker families.
+
+Recommended worker families:
+
+- `jules-issue-worker`
+- `jules-batch-comment-worker`
+- `jules-ci-repair-worker`
+- `jules-doc-worker`
+- `jules-maintenance-worker`
+- `jules-pr-compiler`
+
+Each worker should accept inputs such as:
+
+- issue number
+- task class
+- branch mode
+- validation profile
+- prompt template
+- max scope
+
+### 3. Shared utilities
+
+Create shared patterns for:
+
+- source lookup
+- session creation
+- polling
+- workflow summary reporting
+- branch creation and reuse
+- PR creation and update
+- retry and cooldown logic
+
+This will reduce drift across current Jules workflows.
+
+## Parallel Agent Strategy
+
+Parallelism is useful, but only if it is disciplined.
+
+### Rule 1: Parallelize by issue, not by intuition
+
+Parallel Jules sessions should correspond to different issues or different explicitly partitioned work items.
+
+Bad pattern:
+
+- several sessions editing the same subsystem with overlapping scope
+
+Good pattern:
+
+- one issue for docs
+- one issue for test generation
+- one issue for a bounded refactor in a specific module
+
+### Rule 2: Mark issues as parallel-safe or exclusive
+
+Use labels and issue metadata to state whether an issue can run in parallel.
+
+- `parallel:allowed` means branch-isolated, bounded work
+- `parallel:exclusive` means only one active automation stream should touch the area
+
+### Rule 3: Scope parallel workers tightly
+
+Parallel Jules sessions should be constrained by:
+
+- file list
+- directory list
+- issue acceptance criteria
+- narrow prompt instructions
+
+### Rule 4: Reuse PRs where appropriate
+
+If an issue already has an open PR, subsequent Jules runs for that issue should update the same branch and PR where possible instead of opening a new one.
+
+### Rule 5: Consolidate after fan-out
+
+Parallelism should end with cleanup:
+
+- merge compatible work
+- close superseded PRs
+- archive stale branches
+- compile related PRs when review surface is too fragmented
+
+The existing `Jules-PR-Compiler` is the right pattern to keep.
+
+## Clean Codebase Rules
+
+Parallel automation becomes dangerous when it floods the repo with branches, stale PRs, and partial fixes. The system should actively resist that.
+
+### Branch discipline
+
+Use predictable naming conventions:
+
+- `jules/issue-<num>-<slug>`
+- `jules/review-fix-<pr>-<timestamp>`
+- `jules/ci-fix-<run-id>`
+- `jules/compiled-<category>-<date>`
+
+One issue should map to one primary working branch unless there is an explicit fan-out plan.
+
+### PR discipline
+
+Every automated PR should state:
+
+- originating issue
+- task class
+- validation run
+- whether it supersedes another PR
+
+### Duplicate prevention
+
+Before dispatching a new Jules task, the orchestrator should check:
+
+- is there already an open PR for this issue
+- is there already an active workflow run for this issue
+- is the issue already labeled `jules:assigned` or `jules:queued`
+- has the issue been marked superseded
+
+### Queue hygiene
+
+Batch and deduplicate where possible.
+
+The current comment collector and comment processor already show the right idea:
+
+- collect noisy micro-events
+- deduplicate them
+- process them as a batch
+
+The same principle should apply to:
+
+- issue triage
+- review-followup tasks
+- maintenance chores
+
+### Cleanup policy
+
+Every automation cycle should include cleanup behavior:
+
+- close stale automation branches after merge
+- label superseded issues and PRs
+- compile fragmented related PRs
+- stop creating new PRs when an existing PR can be reused
+
+## Issue Lifecycle
+
+The following state model should govern automated issue handling.
+
+### 1. Intake
+
+Issue is created or labeled for automation.
+
+Expected labels:
+
+- `jules:ready`
+- one task-class label
+- one risk label
+
+### 2. Triage
+
+The control tower determines:
+
+- is the issue automatable
+- should it be queued now
+- is it parallel-safe
+- does an existing branch or PR already exist
+
+Possible outcomes:
+
+- queue for Jules
+- batch with related work
+- mark `jules:needs-human`
+- mark `parallel:exclusive`
+
+### 3. Dispatch
+
+The worker launches a Jules session and writes back:
+
+- session started
+- branch chosen
+- workflow run URL
+- expected validation profile
+
+### 4. Execution
+
+Jules works on the assigned branch with issue-bounded instructions.
+
+### 5. Validation
+
+Worker runs the required validation profile and reports results.
+
+### 6. Delivery
+
+Worker creates or updates a PR and links it back to the issue.
+
+### 7. Consolidation
+
+If multiple related PRs exist, the compiler decides whether to group them.
+
+### 8. Closure
+
+Issue is closed or relabeled based on outcome:
+
+- `jules:done`
+- `jules:blocked`
+- `jules:needs-human`
+
+## Batch-Oriented Operating Modes
+
+Not all issue work should run immediately.
+
+### Immediate mode
+
+Use for:
+
+- CI failures
+- urgent regression fixes
+- explicitly requested issue dispatch
+
+### Scheduled batch mode
+
+Use for:
+
+- review comments
+- docs hygiene
+- cleanup
+- low-priority issue sweeps
+- tech debt clusters
+
+### Overnight mode
+
+Use for:
+
+- larger issue sets
+- refactoring clusters
+- test generation
+- PR compilation
+
+The current repository already leans in this direction, and that is a good pattern to preserve.
+
+## Recommended Worker Families
+
+### Jules Issue Worker
+
+Purpose:
+
+- process one issue or one small issue bundle
+
+Responsibilities:
+
+- check labels and existing PR state
+- create or reuse branch
+- package issue context into prompt
+- run validation
+- create or update PR
+- post structured issue summary
+
+### Jules Batch Comment Worker
+
+Purpose:
+
+- process queued PR review comments in batches
+
+Responsibilities:
+
+- deduplicate comments
+- group by PR
+- reuse PR branch if possible
+- apply only actionable code changes
+
+### Jules CI Repair Worker
+
+Purpose:
+
+- fix CI failures from workflow runs
+
+Responsibilities:
+
+- pull failed logs
+- create minimal repair branch
+- apply bounded remediation
+- stop after retry ceiling
+
+### Jules Maintenance Worker
+
+Purpose:
+
+- run scheduled cleanup or hygiene work
+
+Responsibilities:
+
+- handle low-risk repetitive issue classes
+- avoid creating unnecessary PR noise
+- consolidate changes by category
+
+### Jules PR Compiler
+
+Purpose:
+
+- reduce review fragmentation
+
+Responsibilities:
+
+- detect compatible automated PRs
+- compile by category or issue family
+- close or supersede fragmented PRs
+
+## Prompting Strategy
+
+Parallel automation stays cleaner when prompts are narrow and structured.
+
+Each prompt should include:
+
+- issue number and title
+- exact scope
+- acceptance criteria
+- forbidden actions
+- validation commands
+- branch expectations
+- PR expectations
+
+Prompt rules:
+
+- ask for minimal focused changes
+- forbid unrelated refactors unless the task class is refactor
+- require updating existing PRs when they exist
+- require issue references in commit and PR text where appropriate
+
+## Validation Profiles
+
+Every task class should map to a validation profile.
+
+### Profile A: docs and metadata
+
+- markdown or docs checks as needed
+- path and link sanity
+
+### Profile B: bounded code cleanup
+
+- formatter
+- linter
+- targeted tests
+
+### Profile C: risky implementation
+
+- formatter
+- linter
+- type checks
+- targeted tests
+- relevant integration tests if available
+
+Workers should not guess validation. It should be configured by task class.
+
+## Suggested Branch and PR Reuse Rules
+
+### Reuse branch when
+
+- the issue already has an open automation PR
+- the new work is a continuation of the same issue
+- review comments target the same PR
+
+### Create a new branch when
+
+- the issue is distinct
+- the existing branch has drifted too far
+- the new task is intentionally isolated
+
+### Compile PRs when
+
+- there are multiple open PRs in the same category
+- review burden is too high
+- branches are independent and merge-clean
+
+### Do not compile when
+
+- PRs solve unrelated issues
+- the merge surface is risky
+- one PR is awaiting focused human review
+
+## Operational Metrics
+
+Track these metrics in workflow summaries or dashboards:
+
+- queue depth by task class
+- active Jules sessions
+- issue-to-PR conversion rate
+- median time from issue ready to PR
+- duplicate-dispatch rate
+- superseded PR count
+- merge conflict rate in compiled PRs
+- ratio of immediate versus batched work
+
+These metrics will tell you whether automation is helping or just generating churn.
+
+## Rollout Phases
+
+### Phase 0: Documentation and policy normalization
+
+Deliverables:
+
+- issue schema
+- label taxonomy
+- branch naming rules
+- PR body conventions
+- worker family map
+
+### Phase 1: Issue-first routing
+
+Deliverables:
+
+- route issues through one control tower
+- normalize `ready`, `assigned`, `blocked`, and `done` states
+- add duplicate-dispatch checks
+
+### Phase 2: Safe parallelism
+
+Deliverables:
+
+- `parallel:allowed` and `parallel:exclusive` model
+- branch reuse policy
+- issue-bound worker prompts
+
+### Phase 3: Queue hygiene and batching
+
+Deliverables:
+
+- issue batching rules
+- comment batching hardening
+- stale queue cleanup
+- supersede handling
+
+### Phase 4: PR cleanliness
+
+Deliverables:
+
+- broader PR compiler policy
+- stale branch cleanup
+- one-issue-one-primary-PR guideline
+
+### Phase 5: Metrics and hardening
+
+Deliverables:
+
+- dashboard or summary reports
+- clearer retry and stop policies
+- review of workflow sprawl
+
+## Initial Backlog For This Approach
+
+These are the first concrete planning or implementation issues I would create.
+
+1. Define canonical Jules issue template for automatable work.
+2. Define canonical Jules labels for status, task class, risk, and parallelism.
+3. Refactor control tower design into a single issue-first router.
+4. Create a reusable issue worker contract for Jules workflows.
+5. Add duplicate-dispatch and existing-PR checks before every Jules launch.
+6. Standardize branch naming and PR metadata for all Jules workflows.
+7. Formalize comment batching and issue batching rules.
+8. Expand PR compilation policy to reduce review fragmentation.
+9. Define validation profiles by task class.
+10. Add cleanup policies for stale automation branches, PRs, and superseded queue items.
+
+## Recommended Near-Term Strategy
+
+If the goal is to automate aggressively while keeping the codebase clean, the best next step is:
+
+1. treat GitHub Issues as the only work queue for autonomous coding
+2. standardize issue metadata and labels
+3. route everything through one control tower
+4. allow parallel Jules work only on bounded, label-approved issues
+5. clean up aggressively through PR reuse, batching, and compilation
+
+That gives you the benefits of autonomous parallel cloud execution without immediately inheriting the complexity of multi-backend orchestration.
+
+## Appendix: Repository Workflows This Plan Builds On
+
+- `/.github/workflows/Jules-Control-Tower.yml`
+- `/.github/workflows/Jules-Issue-Resolver.yml`
+- `/.github/workflows/Jules-Hotfix-Creator.yml`
+- `/.github/workflows/Jules-Comment-Processor.yml`
+- `/.github/workflows/PR-Comment-Responder.yml`
+- `/.github/workflows/Jules-PR-Compiler.yml`
+- `/.github/workflows/Jules-Auto-Assign-Issues.yml`

--- a/docs/plans/JULES_ONLY_IMPLEMENTATION_GUIDE_2026-03-19.md
+++ b/docs/plans/JULES_ONLY_IMPLEMENTATION_GUIDE_2026-03-19.md
@@ -1,0 +1,610 @@
+# Jules-Only Orchestration Implementation Guide
+
+Date: 2026-03-19
+
+## Purpose
+
+This guide translates the Jules-only orchestration plan into implementation instructions detailed enough for agents to execute consistently across repositories.
+
+It answers four practical questions:
+
+1. What do we version-control?
+2. How do we trigger the workflows?
+3. How do we pause, resume, and operate them safely?
+4. How do we keep Jules-managed PRs moving toward green CI without creating unsafe automation loops?
+
+## Implementation Goal
+
+Stand up a reusable GitHub-native Jules automation layer that can be copied repo to repo and controlled primarily through:
+
+- checked-in workflow files
+- checked-in policy/config files
+- GitHub labels
+- issue templates
+- workflow dispatch inputs
+- repository variables and secrets
+
+The design should require no local daemon and minimal operator intervention once configured.
+
+## What Must Be Version-Controlled
+
+These parts of the system should be committed to every participating repository:
+
+### Workflow entrypoints
+
+- top-level control tower workflow
+- issue worker workflow
+- CI repair workflow
+- PR shepherd workflow
+- comment batching workflow
+- PR compiler workflow
+- cleanup workflow
+
+### Workflow policy files
+
+- task-class to validation-profile mapping
+- branch naming rules
+- pause/resume behavior
+- retry ceilings
+- schedule defaults
+- label names and meanings
+
+### GitHub-facing contract
+
+- issue template for automatable work
+- pull request body fragments or template text
+- slash command policy
+- operator runbook
+
+### Suggested repository paths
+
+- `.github/workflows/jules-control-tower.yml`
+- `.github/workflows/jules-issue-worker.yml`
+- `.github/workflows/jules-ci-repair.yml`
+- `.github/workflows/jules-pr-shepherd.yml`
+- `.github/workflows/jules-comment-collector.yml`
+- `.github/workflows/jules-comment-processor.yml`
+- `.github/workflows/jules-pr-compiler.yml`
+- `.github/workflows/jules-cleanup.yml`
+- `.github/ISSUE_TEMPLATE/jules_task.yml`
+- `.github/jules/policy.yml`
+- `.github/jules/task_classes.yml`
+- `.github/jules/validation_profiles.yml`
+- `docs/operations/jules-orchestration-runbook.md`
+
+### What should not be version-controlled
+
+- `JULES_API_KEY`
+- bot tokens
+- temporary provider credentials
+- live workflow runtime state that belongs in GitHub issues, PRs, or workflow metadata instead
+
+## Required GitHub Secrets And Variables
+
+### Secrets
+
+- `JULES_API_KEY`
+- `GITHUB_TOKEN` for standard repo operations
+- optional elevated bot token if cross-repo or restricted operations require it
+
+### Variables
+
+- `JULES_AUTOMATION_ENABLED`
+- `JULES_AUTOMATION_PAUSED`
+- `JULES_MAX_PARALLEL_ISSUES`
+- `JULES_MAX_PR_REPAIR_ATTEMPTS`
+- `JULES_ALLOWED_SCHEDULES`
+- `JULES_DEFAULT_BRANCH`
+
+Recommended defaults:
+
+- `JULES_AUTOMATION_ENABLED=true`
+- `JULES_AUTOMATION_PAUSED=false`
+- `JULES_MAX_PARALLEL_ISSUES=3`
+- `JULES_MAX_PR_REPAIR_ATTEMPTS=3`
+
+## Triggering Model
+
+The orchestration layer should support four trigger families.
+
+### 1. Automatic issue triggers
+
+Use when:
+
+- a new issue is created from an automation workflow
+- an issue is labeled `jules:ready`
+- an issue is labeled with a task class and risk level
+
+Recommended events:
+
+- `issues: opened`
+- `issues: labeled`
+- `issues: reopened`
+
+Recommended behavior:
+
+- validate issue metadata
+- reject or relabel malformed issues
+- queue valid issues for the control tower
+
+### 2. Scheduled triggers
+
+Use when:
+
+- you want regular triage or batch processing
+- you want predictable overnight work windows
+- you want a PR shepherd sweep to catch stalled automation
+
+Recommended schedules:
+
+- every 15 or 30 minutes for queue sweeps if load is light
+- hourly or every few hours for maintenance clusters
+- overnight batches for lower-priority cleanup and refactor work
+- periodic PR shepherd sweep in addition to event-driven CI monitoring
+
+### 3. Manual triggers
+
+Use when:
+
+- an operator wants to run the queue now
+- an operator wants to force a specific issue or PR through a worker
+- an operator wants to retry, compile, or clean up immediately
+
+Recommended support:
+
+- `workflow_dispatch` with explicit inputs
+- issue comment commands such as `/jules-run`
+- issue comment commands such as `/jules-retry`
+- PR comment commands such as `/jules-fix-ci`
+- manual `target` choices in the control tower
+
+### 4. CI event triggers
+
+Use when:
+
+- a workflow run fails on a Jules-managed PR
+- a protected branch CI failure needs urgent action
+- a Jules PR becomes mergeable or blocked
+
+Recommended events:
+
+- `workflow_run: completed`
+- optional `check_suite: completed`
+
+Recommended behavior:
+
+- inspect whether the PR or branch is Jules-managed
+- apply retry ceilings and cooldown windows
+- route to PR shepherd or CI repair worker as appropriate
+
+## Manual Shortcuts For Operators
+
+The system should provide predictable manual shortcuts that avoid editing workflow files or relabeling by hand.
+
+### Recommended issue commands
+
+- `/jules-run`
+- `/jules-retry`
+- `/jules-pause`
+- `/jules-resume`
+- `/jules-status`
+- `/jules-batch-now`
+
+### Recommended PR commands
+
+- `/jules-fix-ci`
+- `/jules-address-comments`
+- `/jules-retry-validation`
+- `/jules-stop`
+
+These commands should be handled by a lightweight comment-command router workflow that:
+
+- authenticates actor permissions
+- translates commands into labels or `workflow_dispatch`
+- records the command invocation visibly in issue or PR comments
+
+## Pause, Resume, And Safe Stop Design
+
+Yes, the system should support pausing.
+
+Pausing is important for:
+
+- high-risk incidents
+- branch protection changes
+- CI outages
+- provider issues
+- noisy or unsafe automation behavior
+
+### Global pause
+
+Implement via repository variable:
+
+- `JULES_AUTOMATION_PAUSED=true`
+
+Control-tower behavior when paused:
+
+- do not dispatch new work
+- allow in-flight workflows to finish unless the worker is explicitly stop-capable
+- comment or summarize that the repo is paused
+
+### Scoped pause
+
+Implement via labels or variable subsets:
+
+- `pause:jules-ci-repair`
+- `pause:jules-issue-worker`
+- `pause:jules-pr-shepherd`
+
+This allows you to pause one automation class without freezing the entire system.
+
+### Per-issue pause
+
+Implement via issue label:
+
+- `jules:blocked`
+
+or command:
+
+- `/jules-pause`
+
+### Resume behavior
+
+On resume:
+
+- the control tower should sweep queued items
+- stale in-progress state should be reconciled
+- no issue should be dispatched twice
+
+## Detailed Workflow Set
+
+### 1. Control Tower
+
+Purpose:
+
+- central routing and gating layer
+
+Triggers:
+
+- issues opened, labeled, reopened
+- issue comment commands
+- workflow_run completed
+- schedule
+- workflow_dispatch
+
+Responsibilities:
+
+- check repo pause state
+- validate issue or PR eligibility
+- prevent duplicate dispatch
+- select worker family
+- enforce max parallel limit
+- write status labels or comments
+
+### 2. Issue Worker
+
+Purpose:
+
+- process one automatable issue
+
+Inputs:
+
+- issue number
+- task class
+- validation profile
+- branch mode
+- max scope
+
+Responsibilities:
+
+- gather issue context
+- find or create working branch
+- reuse an open PR if present
+- dispatch Jules session
+- poll for result
+- run validation
+- create or update PR
+- post structured completion report
+
+### 3. Comment Collector And Processor
+
+Purpose:
+
+- collect noisy review comments and address them in batches
+
+Collector responsibilities:
+
+- capture actionable comments
+- ignore bots and closed PRs
+- queue comments into checked-in or transient structured storage
+
+Processor responsibilities:
+
+- deduplicate comments
+- group by PR
+- reuse PR branch
+- dispatch a bounded Jules session
+- avoid opening new PRs unnecessarily
+
+### 4. CI Repair Worker
+
+Purpose:
+
+- repair failed CI on Jules-managed branches or critical branches
+
+Responsibilities:
+
+- fetch failed logs
+- decide whether failure class is automatable
+- create or reuse repair branch
+- dispatch minimal Jules repair prompt
+- stop after retry ceiling
+
+### 5. PR Shepherd
+
+Purpose:
+
+- keep open Jules-managed PRs moving toward green CI and review completion
+
+This is the missing piece that answers your question about iterating on open PRs until they pass CI/CD.
+
+Yes, you can create one, but it must be careful and bounded.
+
+## PR Shepherd Design
+
+Jules is not naturally a continuous monitor, so the workflow should be event-driven and sweep-based rather than trying to keep a long-running watch process.
+
+### Trigger conditions
+
+Use two trigger modes:
+
+- `workflow_run: completed` for relevant CI workflows
+- scheduled sweep every few hours for open Jules-managed PRs
+
+### Eligibility rules
+
+Only act if all are true:
+
+- PR author or labels mark it as Jules-managed
+- PR is open
+- PR is not draft unless explicitly allowed
+- PR is not labeled `jules:needs-human`
+- PR has not exceeded repair ceiling
+- repo is not paused
+
+### What the shepherd should do
+
+1. inspect the latest CI results
+2. classify whether the failures are automatable
+3. if automatable, dispatch a bounded fix attempt on the same branch
+4. post a structured progress comment
+5. increment repair-attempt count
+6. stop and escalate if attempts exceed configured ceiling
+
+### What the shepherd must not do
+
+- loop forever on the same PR
+- create a new PR for every repair attempt
+- repair failures on human-owned PRs unless explicitly labeled
+- keep retrying when the failures are flaky, infrastructural, or ambiguous
+
+### Retry policy
+
+Recommended defaults:
+
+- maximum 3 repair attempts per PR per 24 hours
+- cooldown of at least 15 to 30 minutes between attempts
+- immediate stop if failure class is not confidently automatable
+
+### Failure classes suitable for automatic repair
+
+- formatting
+- import ordering
+- obvious lint violations
+- missing type imports
+- straightforward test breakages tied to the PR changes
+
+### Failure classes that should escalate instead
+
+- flaky infrastructure
+- unrelated baseline breakage
+- merge conflicts
+- heavy integration failures
+- security-sensitive changes
+- broad architectural regressions
+
+## Scheduling Recommendations
+
+Yes, scheduling should be part of the design.
+
+Recommended schedule families:
+
+### Fast loop
+
+- queue sweep every 15 to 30 minutes
+- command router every few minutes if needed
+
+### Business-hours support
+
+- PR shepherd every 1 to 3 hours
+- CI repair immediately on workflow completion
+
+### Overnight batch
+
+- issue cleanup
+- comment processing
+- PR compilation
+- docs and tech debt clusters
+
+### Weekly hygiene
+
+- stale PR cleanup
+- stale issue reconciliation
+- automation metrics summary
+
+## Cross-Repository Rollout Strategy
+
+To support this pattern across all repos, treat the orchestration layer as a reusable package of policy and workflow files.
+
+### Recommended rollout order
+
+1. create the standard docs and policy files
+2. create the standard labels
+3. add the control tower and issue worker
+4. add comment batching
+5. add PR shepherd
+6. add cleanup and compiler workflows
+
+### Repo onboarding checklist
+
+Each repo should have:
+
+- Jules API secret configured
+- standard labels installed
+- issue template installed
+- baseline CI workflow names mapped
+- pause variable configured
+- allowed schedules reviewed
+- maintainer owner list defined for command authorization
+
+### Merge strategy across repos
+
+For each repo:
+
+- create a dedicated orchestration branch
+- open one setup PR
+- validate workflow syntax and permissions
+- merge only after CI and dry-run validation pass
+
+Do not roll out the full active automation set to every repo at once. Start with:
+
+- labels
+- issue template
+- control tower in report-only or dry-run mode
+- issue worker on explicitly labeled issues only
+
+## Suggested Dry-Run And Safety Modes
+
+Every major workflow should support a dry-run mode.
+
+### Dry-run behavior
+
+- analyze targets
+- summarize planned action
+- do not dispatch Jules
+- do not create PRs
+- do not mutate branches
+
+### Limited-launch mode
+
+Recommended initial flag:
+
+- only dispatch on issues labeled `jules:ready`
+
+This prevents accidental repository-wide activation during rollout.
+
+## Detailed Implementation Backlog
+
+These are the first implementation issues I recommend creating.
+
+### Epic
+
+- Stand up a reusable Jules-only GitHub issue orchestration control plane for this repository.
+
+### Issue 1
+
+- Define the canonical label taxonomy, issue template, and policy files.
+
+Expected outputs:
+
+- standard labels
+- issue template
+- `.github/jules/*.yml` policy files
+
+### Issue 2
+
+- Build `jules-control-tower.yml` v2 with pause checks, duplicate-dispatch protection, and manual dispatch inputs.
+
+Expected outputs:
+
+- central router
+- dry-run mode
+- schedule support
+- command routing support
+
+### Issue 3
+
+- Build `jules-issue-worker.yml` with branch reuse, PR reuse, validation profiles, and structured issue reporting.
+
+Expected outputs:
+
+- one issue to one branch/PR pattern
+- bounded session dispatch
+- post-run summary comments
+
+### Issue 4
+
+- Build comment collection and batch-processing workflows with deduplication and safe PR reuse.
+
+Expected outputs:
+
+- stable queue structure
+- grouped PR comment handling
+- no PR cascades
+
+### Issue 5
+
+- Build `jules-pr-shepherd.yml` to iterate carefully on open Jules-managed PRs until they pass CI or hit bounded stop conditions.
+
+Expected outputs:
+
+- event-driven CI monitoring
+- scheduled sweep
+- retry ceiling
+- cooldown handling
+- escalation comments
+
+### Issue 6
+
+- Build cleanup and PR compiler workflows to reduce branch and PR sprawl.
+
+Expected outputs:
+
+- stale branch cleanup
+- stale automation PR policy
+- compiled PR creation rules
+
+### Issue 7
+
+- Write the operator runbook covering trigger methods, pause/resume, failure handling, and cross-repo rollout.
+
+Expected outputs:
+
+- `docs/operations` runbook
+- troubleshooting and safety procedures
+
+## Agent Execution Instructions
+
+When agents implement this system, they should follow these rules:
+
+1. Do not introduce auto-dispatch for all issues at once.
+2. Start with explicit labels and dry-run support.
+3. Reuse branches and PRs whenever possible.
+4. Do not create infinite repair or retry loops.
+5. Keep workflow logic centralized where possible.
+6. Prefer report-only mode before mutation mode.
+7. Every workflow must write enough structured output for a human to audit what happened.
+8. Every workflow must have clear stop conditions.
+9. Every new workflow must document required labels, variables, and secrets.
+10. Roll out one repo at a time until the pattern is proven stable.
+
+## Recommended Near-Term Decision
+
+The next implementation step should be:
+
+1. merge the planning and implementation docs
+2. create the epic and first implementation issues
+3. build the version-controlled policy layer first
+4. then build the control tower and issue worker
+5. then add PR shepherding carefully after the issue pipeline is stable
+
+That sequence gives you a version-controlled foundation, clean operator control, and a path toward automated PR convergence without trying to solve all workflow classes at once.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,6 +19,8 @@ This directory contains implementation plans, roadmaps, and strategic documentat
 
 - [priority_improvements_jan_2026.md](priority_improvements_jan_2026.md) - High-priority improvements for January 2026
 - [IMPLEMENTATION_CHECKLIST.md](IMPLEMENTATION_CHECKLIST.md) - Implementation task checklist
+- [JULES_ONLY_GITHUB_ISSUE_ORCHESTRATION_PLAN_2026-03-19.md](JULES_ONLY_GITHUB_ISSUE_ORCHESTRATION_PLAN_2026-03-19.md) - GitHub-native Jules-only issue orchestration strategy
+- [JULES_ONLY_IMPLEMENTATION_GUIDE_2026-03-19.md](JULES_ONLY_IMPLEMENTATION_GUIDE_2026-03-19.md) - Detailed implementation instructions for Jules-only orchestration
 
 ## Reviews and Analysis
 


### PR DESCRIPTION
## Summary

This PR adds the first version-controlled foundation for a Jules-only GitHub issue orchestration approach.

It introduces:
- a Jules-only orchestration plan
- a detailed implementation guide with workflow triggers, pause/resume controls, manual shortcuts, scheduling guidance, and PR shepherd design
- a version-controlled policy example under `.github/jules/`

## Why

The repository already has a meaningful Jules workflow surface, but the operating model is fragmented across many workflows and is not yet standardized enough to be rolled out cleanly across repositories.

This PR creates the planning and implementation artifacts needed to:
- treat GitHub Issues as the durable work queue
- use GitHub Actions as the control plane
- support safe parallel Jules execution
- keep branches and PRs clean through reuse, batching, and compilation
- define a careful path for PR iteration until CI/CD passes without creating unsafe loops

## Files Added

- `docs/plans/JULES_ONLY_GITHUB_ISSUE_ORCHESTRATION_PLAN_2026-03-19.md`
- `docs/plans/JULES_ONLY_IMPLEMENTATION_GUIDE_2026-03-19.md`
- `.github/jules/policy.example.yml`

## Follow-up

After this PR is open, implementation should begin through GitHub issues created from the implementation guide. Those issues should cover:
- label taxonomy and issue template
- control tower v2
- issue worker
- comment batching
- PR shepherd
- cleanup/compiler
- operator runbook
