### PR TITLE
refactor: add shared Jules GitHub helper layer

### DIFF
--- a/.github/jules/scripts/gh_helpers.py
+++ b/.github/jules/scripts/gh_helpers.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Small helper CLI for Jules GitHub workflow operations.
+
+This script is intentionally lightweight so GitHub Actions workflows can reuse
+the same JSON parsing and step-summary rendering logic without duplicating large
+inline Python blocks across multiple workflow files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def _run_json(command: list[str]) -> object:
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def issue_context(repo: str, issue_number: str, task_classes_path: str) -> int:
+    issue = _run_json(
+        [
+            "gh",
+            "issue",
+            "view",
+            issue_number,
+            "--repo",
+            repo,
+            "--json",
+            "number,title,body,labels,url",
+        ]
+    )
+
+    import re
+    import yaml
+
+    labels = [label["name"] for label in issue.get("labels", [])]
+    with open(task_classes_path, "r", encoding="utf-8") as handle:
+        task_classes = yaml.safe_load(handle)["task_classes"]
+
+    task_class = "triage"
+    validation_profile = "docs"
+    task_label = "jules:triage"
+    for name, config in task_classes.items():
+        label = config.get("label")
+        if label in labels:
+            task_class = name
+            task_label = label
+            validation_profile = config.get("validation_profile", "docs")
+            break
+
+    slug = re.sub(r"[^a-z0-9]+", "-", issue["title"].lower()).strip("-")[:40] or "task"
+    branch_prefix = f"jules/issue-{issue['number']}-"
+    payload = {
+        "title": issue["title"],
+        "task_class": task_class,
+        "task_label": task_label,
+        "validation_profile": validation_profile,
+        "slug": slug,
+        "branch_prefix": branch_prefix,
+    }
+    print(json.dumps(payload))
+    return 0
+
+
+def pr_lookup(repo: str, issue_number: str, branch_prefix: str) -> int:
+    prs = _run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,title,body",
+        ]
+    )
+    issue_ref = f"#{issue_number}"
+    issue_title_ref = f"issue #{issue_number}"
+    match = None
+    for pr in prs:
+        body = pr.get("body") or ""
+        title = pr.get("title") or ""
+        head = pr.get("headRefName") or ""
+        if head.startswith(branch_prefix) or issue_ref in body or issue_title_ref in title.lower():
+            match = pr
+            break
+    print(json.dumps(match or {}))
+    return 0
+
+
+def collect_pr_comments(repo: str, pr_number: str) -> int:
+    review_comments = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+        ]
+    )
+    issue_comments = _run_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments?per_page=100",
+        ]
+    )
+
+    actionable_terms = [
+        "please",
+        "should",
+        "could you",
+        "can you",
+        "fix",
+        "change",
+        "update",
+        "add",
+        "remove",
+        "consider",
+        "suggest",
+        "recommend",
+    ]
+    ignored_authors = {
+        "copilot-pull-request-reviewer[bot]",
+        "cursor[bot]",
+        "dependabot[bot]",
+        "github-actions[bot]",
+        "renovate[bot]",
+        "codecov[bot]",
+        "sonarcloud[bot]",
+    }
+
+    def is_actionable(body: str) -> bool:
+        text = (body or "").lower()
+        return any(term in text for term in actionable_terms) or "?" in text
+
+    comments = []
+    for source, items in [("review", review_comments), ("pr", issue_comments)]:
+        for item in items:
+            author = item.get("user", {}).get("login", "")
+            body = item.get("body", "")
+            if author in ignored_authors or not is_actionable(body):
+                continue
+            comments.append(
+                {
+                    "comment_id": item.get("id"),
+                    "author": author,
+                    "body": body,
+                    "type": source,
+                    "path": item.get("path"),
+                    "line": item.get("line"),
+                    "created_at": item.get("created_at"),
+                }
+            )
+
+    seen = set()
+    deduped = []
+    for comment in comments:
+        snippet = (comment["body"] or "")[:120]
+        key = (comment["author"], comment["path"], comment["line"], snippet)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(comment)
+
+    grouped = defaultdict(list)
+    for comment in deduped:
+        grouped[comment.get("path") or "general"].append(comment)
+
+    payload = {
+        "pr_number": pr_number,
+        "comment_count": len(deduped),
+        "comments": deduped,
+        "grouped_by_path": grouped,
+    }
+    print(json.dumps(payload, indent=2, default=list))
+    return 0
+
+
+def write_summary(output: str, title: str, items: list[str]) -> int:
+    path = Path(output)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"## {title}\n\n")
+        for item in items:
+            handle.write(f"- {item}\n")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Jules GitHub workflow helpers")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    issue_parser = subparsers.add_parser("issue-context")
+    issue_parser.add_argument("--repo", required=True)
+    issue_parser.add_argument("--issue-number", required=True)
+    issue_parser.add_argument("--task-classes", required=True)
+
+    pr_lookup_parser = subparsers.add_parser("pr-lookup")
+    pr_lookup_parser.add_argument("--repo", required=True)
+    pr_lookup_parser.add_argument("--issue-number", required=True)
+    pr_lookup_parser.add_argument("--branch-prefix", required=True)
+
+    comment_parser = subparsers.add_parser("collect-pr-comments")
+    comment_parser.add_argument("--repo", required=True)
+    comment_parser.add_argument("--pr-number", required=True)
+
+    summary_parser = subparsers.add_parser("write-summary")
+    summary_parser.add_argument("--output", required=True)
+    summary_parser.add_argument("--title", required=True)
+    summary_parser.add_argument("items", nargs="*")
+
+    args = parser.parse_args()
+
+    if args.command == "issue-context":
+      return issue_context(args.repo, args.issue_number, args.task_classes)
+    if args.command == "pr-lookup":
+      return pr_lookup(args.repo, args.issue_number, args.branch_prefix)
+    if args.command == "collect-pr-comments":
+      return collect_pr_comments(args.repo, args.pr_number)
+    if args.command == "write-summary":
+      return write_summary(args.output, args.title, args.items)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/jules-comment-batch-processor.yml
+++ b/.github/workflows/jules-comment-batch-processor.yml
@@ -102,78 +102,17 @@ jobs:
       - name: Collect Actionable Comments From GitHub
         id: comments
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/pulls/${{ steps.target.outputs.pr_number }}/comments?per_page=100" > /tmp/jules_review_comments.json
-          gh api "repos/$GITHUB_REPOSITORY/issues/${{ steps.target.outputs.pr_number }}/comments?per_page=100" > /tmp/jules_issue_comments.json
+          python3 .github/jules/scripts/gh_helpers.py collect-pr-comments \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr-number "${{ steps.target.outputs.pr_number }}" \
+            > /tmp/jules_comment_batch.json
 
           python3 <<'PY'
           import json
           import os
-          from collections import defaultdict
-
-          actionable_terms = [
-              "please", "should", "could you", "can you", "fix",
-              "change", "update", "add", "remove", "consider",
-              "suggest", "recommend"
-          ]
-          ignored_authors = {
-              "copilot-pull-request-reviewer[bot]",
-              "cursor[bot]",
-              "dependabot[bot]",
-              "github-actions[bot]",
-              "renovate[bot]",
-              "codecov[bot]",
-              "sonarcloud[bot]",
-          }
-
-          def is_actionable(body: str) -> bool:
-              text = (body or "").lower()
-              return any(term in text for term in actionable_terms) or "?" in text
-
-          comments = []
-          for source, path in [("review", "/tmp/jules_review_comments.json"), ("pr", "/tmp/jules_issue_comments.json")]:
-              for item in json.load(open(path)):
-                  author = item.get("user", {}).get("login", "")
-                  body = item.get("body", "")
-                  if author in ignored_authors:
-                      continue
-                  if not is_actionable(body):
-                      continue
-                  comments.append({
-                      "comment_id": item.get("id"),
-                      "author": author,
-                      "body": body,
-                      "type": source,
-                      "path": item.get("path"),
-                      "line": item.get("line"),
-                      "created_at": item.get("created_at"),
-                  })
-
-          seen = set()
-          deduped = []
-          for comment in comments:
-              snippet = (comment["body"] or "")[:120]
-              key = (comment["author"], comment["path"], comment["line"], snippet)
-              if key in seen:
-                  continue
-              seen.add(key)
-              deduped.append(comment)
-
-          grouped = defaultdict(list)
-          for comment in deduped:
-              grouped[comment.get("path") or "general"].append(comment)
-
-          payload = {
-              "pr_number": "${{ steps.target.outputs.pr_number }}",
-              "comment_count": len(deduped),
-              "comments": deduped,
-              "grouped_by_path": grouped,
-          }
-
-          with open("/tmp/jules_comment_batch.json", "w", encoding="utf-8") as fh:
-              json.dump(payload, fh, indent=2, default=list)
-
+          payload = json.load(open("/tmp/jules_comment_batch.json"))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-              fh.write(f"count={len(deduped)}\n")
+              fh.write(f"count={payload['comment_count']}\n")
           PY
 
       - name: Stop If Nothing To Process

--- a/.github/workflows/jules-issue-worker.yml
+++ b/.github/workflows/jules-issue-worker.yml
@@ -62,47 +62,31 @@ jobs:
       - name: Gather Issue Context
         id: gather
         run: |
-          gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json number,title,body,labels,url > /tmp/jules_issue.json
+          python3 .github/jules/scripts/gh_helpers.py issue-context \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue-number "$ISSUE_NUMBER" \
+            --task-classes ".github/jules/task_classes.yml" \
+            > /tmp/jules_issue_context.json
 
           python3 <<'PY'
           import json
           import os
-          import re
-          import yaml
-
-          issue = json.load(open("/tmp/jules_issue.json"))
-          labels = [label["name"] for label in issue.get("labels", [])]
-          with open(".github/jules/task_classes.yml", "r", encoding="utf-8") as f:
-              task_classes = yaml.safe_load(f)["task_classes"]
-
-          task_class = "triage"
-          validation_profile = "docs"
-          task_label = "jules:triage"
-          for name, config in task_classes.items():
-              label = config.get("label")
-              if label in labels:
-                  task_class = name
-                  task_label = label
-                  validation_profile = config.get("validation_profile", "docs")
-                  break
-
-          slug = re.sub(r"[^a-z0-9]+", "-", issue["title"].lower()).strip("-")[:40]
-          branch_prefix = f"jules/issue-{issue['number']}-"
-          output = os.environ["GITHUB_OUTPUT"]
-          with open(output, "a", encoding="utf-8") as fh:
-              fh.write(f"title={issue['title']}\n")
-              fh.write(f"task_class={task_class}\n")
-              fh.write(f"task_label={task_label}\n")
-              fh.write(f"validation_profile={validation_profile}\n")
-              fh.write(f"slug={slug or 'task'}\n")
-              fh.write(f"branch_prefix={branch_prefix}\n")
+          payload = json.load(open("/tmp/jules_issue_context.json"))
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              for key, value in payload.items():
+                  fh.write(f"{key}={value}\n")
           PY
 
       - name: Find Existing PR Or Branch
         id: branch
         run: |
-          EXISTING=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,headRefName,title,body \
-            --jq '[.[] | select((.headRefName | startswith("${{ steps.gather.outputs.branch_prefix }}")) or (.body // "" | contains("#${{ env.ISSUE_NUMBER }}")) or (.title | contains("issue #${{ env.ISSUE_NUMBER }}")))][0]')
+          python3 .github/jules/scripts/gh_helpers.py pr-lookup \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue-number "$ISSUE_NUMBER" \
+            --branch-prefix "${{ steps.gather.outputs.branch_prefix }}" \
+            > /tmp/jules_pr_lookup.json
+
+          EXISTING=$(cat /tmp/jules_pr_lookup.json)
 
           if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
             BRANCH_NAME=$(echo "$EXISTING" | jq -r '.headRefName')
@@ -138,15 +122,16 @@ jobs:
           echo "Branch: ${{ steps.branch.outputs.branch_name }}"
           echo "Existing PR: ${{ steps.branch.outputs.pr_number }}"
           {
-            echo "## Jules Issue Worker Dry Run"
-            echo ""
-            echo "- Issue: #$ISSUE_NUMBER"
-            echo "- Title: ${{ steps.gather.outputs.title }}"
-            echo "- Task class: \`${{ steps.gather.outputs.task_class }}\`"
-            echo "- Validation profile: \`${{ steps.gather.outputs.validation_profile }}\`"
-            echo "- Branch: \`${{ steps.branch.outputs.branch_name }}\`"
-            echo "- Existing PR: \`${{ steps.branch.outputs.pr_number || 'none' }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+            python3 .github/jules/scripts/gh_helpers.py write-summary \
+              --output "$GITHUB_STEP_SUMMARY" \
+              --title "Jules Issue Worker Dry Run" \
+              "Issue: #$ISSUE_NUMBER" \
+              "Title: ${{ steps.gather.outputs.title }}" \
+              "Task class: ${{ steps.gather.outputs.task_class }}" \
+              "Validation profile: ${{ steps.gather.outputs.validation_profile }}" \
+              "Branch: ${{ steps.branch.outputs.branch_name }}" \
+              "Existing PR: ${{ steps.branch.outputs.pr_number || 'none' }}"
+          }
 
       - name: Prepare Reused Branch
         if: env.DRY_RUN != 'true' && steps.branch.outputs.reused == 'true'
@@ -237,15 +222,16 @@ jobs:
           fi
 
           {
-            echo "## Jules Issue Worker"
-            echo ""
-            echo "- Issue: #$ISSUE_NUMBER"
-            echo "- Branch: \`${{ steps.branch.outputs.branch_name }}\`"
-            echo "- Existing PR: \`${{ steps.branch.outputs.pr_number || 'none' }}\`"
-            echo "- Task class: \`${{ steps.gather.outputs.task_class }}\`"
-            echo "- Validation profile: \`${{ steps.gather.outputs.validation_profile }}\`"
-            echo "- Validation status: \`${VALIDATION_STATUS}\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+            python3 .github/jules/scripts/gh_helpers.py write-summary \
+              --output "$GITHUB_STEP_SUMMARY" \
+              --title "Jules Issue Worker" \
+              "Issue: #$ISSUE_NUMBER" \
+              "Branch: ${{ steps.branch.outputs.branch_name }}" \
+              "Existing PR: ${{ steps.branch.outputs.pr_number || 'none' }}" \
+              "Task class: ${{ steps.gather.outputs.task_class }}" \
+              "Validation profile: ${{ steps.gather.outputs.validation_profile }}" \
+              "Validation status: ${VALIDATION_STATUS}"
+          }
 
       - name: Create Or Update PR
         if: env.DRY_RUN != 'true'


### PR DESCRIPTION
## Summary

This PR adds a small shared helper layer for Jules GitHub workflows.

Included in this slice:
- `.github/jules/scripts/gh_helpers.py`
- refactor of `jules-issue-worker.yml` to use shared issue-context, PR lookup, and summary helpers
- refactor of `jules-comment-batch-processor.yml` to use shared PR comment collection logic

## Why

The Jules orchestration foundation in #25 is now merged, but the workflows still repeated the same GitHub lookup and summary formatting logic inline.

This PR reduces duplication and gives us one place to improve:
- issue context derivation
- PR lookup by issue/branch
- actionable PR comment collection and deduplication
- workflow summary rendering

## Related Issues

- #18
- #21
- #22
- #24

## Validation

- `python3 -m py_compile .github/jules/scripts/gh_helpers.py`
- parsed all `jules-*.yml` workflows with PyYAML
- `git diff --check`
