### PR TITLE
fix: pin mypy to ==1.13.0 for fleet consistency

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
-      - run: pip install ruff==0.14.10 mypy>=1.15.0 bandit==1.7.7 pydocstyle==6.3.0
+      - run: pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pydocstyle==6.3.0
 
       # FIX: Less aggressive Ruff (Errors, Warnings, Imports only)
       - name: Lint


### PR DESCRIPTION
## Summary
- Pin mypy from >=1.15.0 to ==1.13.0 to match fleet-wide version standard

## Test plan
- [ ] CI standard workflow passes with pinned mypy version
- [ ] mypy type checking produces consistent results

🤖 Generated with [Claude Code](https://claude.com/claude-code)