### PR TITLE
fix: raise CI coverage threshold from 10% to 60%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,8 +320,8 @@ omit = [
 
 [tool.coverage.report]
 # Coverage threshold — enforced in CI and locally when running with --cov.
-# Raise this value as coverage improves toward the 60% target (#1630).
-fail_under = 10
+# Raised from 10% to 60% per issue #97; target remains 60% (#1630).
+fail_under = 60
 show_missing = true
 skip_empty = true
 precision = 1


### PR DESCRIPTION
## Summary

- Raises `fail_under` in `pyproject.toml` from `10` to `60`
- The 10% threshold provided no meaningful regression protection
- 60% matches the documented target in issue #1630

## Related Issues

Closes #97

## Test plan
- [ ] CI passes with the new threshold
- [ ] Coverage report shows >= 60% total coverage