### PR TITLE
[codex] split kinematic force helpers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | Primary Language(s) | Python 3.10+, Rust, TypeScript, MATLAB |
 | License | MIT |
 | Current Version | `2.1.0` |
-| Spec Version | `1.0.1` |
+| Spec Version | `1.0.2` |
 | Last Spec Update | `2026-04-06` |
 
 ## 2. Purpose
@@ -130,6 +130,6 @@ The repository is organized around a Python application core with multiple front
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-06 | 1.0.2 | Split the MuJoCo kinematic-forces helper surfaces into smaller internal modules and standardized examples on module-style execution without inline `sys.path` shims. |
 | 2026-04-06 | 1.0.1 | Corrected the repository URL and tightened the root-spec identity block. |
 | 2026-04-06 | 1.0.0 | Initial root spec for `Golf_GAAI_Sandbox` documenting the current Python, UI, Rust, and legacy model layout. |
-

--- a/examples/aerodynamics_demo.py
+++ b/examples/aerodynamics_demo.py
@@ -2,19 +2,13 @@
 
 Usage::
 
-    python3 examples/aerodynamics_demo.py
+    python3 -m examples.aerodynamics_demo
 
 Prints drag, lift, Magnus, and total force magnitudes for a range of
 ball speeds, and shows the effect of toggling individual force components.
 """
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-project_root = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(project_root))
 
 import numpy as np  # noqa: E402
 

--- a/examples/basic_flight_simulation.py
+++ b/examples/basic_flight_simulation.py
@@ -2,19 +2,13 @@
 
 Usage::
 
-    python3 examples/basic_flight_simulation.py
+    python3 -m examples.basic_flight_simulation
 
 Prints a summary table of trajectory points (time, x, z, speed) and
 the estimated carry distance to landing.
 """
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-# Allow running from repo root without installing the package
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import numpy as np
 

--- a/examples/topography_demo.py
+++ b/examples/topography_demo.py
@@ -2,19 +2,13 @@
 
 Usage::
 
-    python3 examples/topography_demo.py
+    python3 -m examples.topography_demo
 
 Creates three terrain types (flat, sloped, undulating), queries elevation
 at a grid of sample points, and prints a small ASCII cross-section.
 """
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-project_root = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(project_root))
 
 import numpy as np  # noqa: E402
 

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_context.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_context.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import mujoco
+import numpy as np
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+def check_mujoco_version() -> None:
+    """Validate MuJoCo version meets minimum requirements."""
+    try:
+        version_str = mujoco.__version__
+        major, minor, *_ = map(int, version_str.split("."))
+
+        if (major, minor) < (3, 3):
+            msg = (
+                f"MuJoCo {version_str} detected, but 3.3.0+ is required.\n"
+                "The reshaped Jacobian API (mj_jacBody with 2D arrays) was "
+                "introduced in MuJoCo 3.3. Earlier versions use flat arrays "
+                "which can cause dimension alignment errors.\n"
+                "Please upgrade: pip install 'mujoco>=3.3.0,<4.0.0'\n"
+                "See Issue F-003 in Assessment C for details."
+            )
+            raise ImportError(msg)
+
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info("MuJoCo version %s validated successfully", version_str)
+    except (AttributeError, ValueError) as exc:
+        warnings.warn(
+            f"Could not validate MuJoCo version: {exc}. "
+            "Proceeding with fallback Jacobian handling.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+
+
+class MjDataContext:
+    """Context manager for safe MuJoCo MjData state isolation."""
+
+    def __init__(self, model: mujoco.MjModel, data: mujoco.MjData) -> None:
+        if not (model is not None):
+            raise ValueError("model must be provided")
+        self.model = model
+        self.data = data
+        self.qpos_backup: np.ndarray | None = None
+        self.qvel_backup: np.ndarray | None = None
+        self.qacc_backup: np.ndarray | None = None
+        self.ctrl_backup: np.ndarray | None = None
+        self.time_backup: float = 0.0
+
+    def __enter__(self) -> mujoco.MjData:
+        self.qpos_backup = self.data.qpos.copy()
+        self.qvel_backup = self.data.qvel.copy()
+        self.qacc_backup = self.data.qacc.copy()
+        self.ctrl_backup = self.data.ctrl.copy()
+        self.time_backup = self.data.time
+        return self.data
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.data.qpos[:] = self.qpos_backup
+        self.data.qvel[:] = self.qvel_backup
+        self.data.qacc[:] = self.qacc_backup
+        self.data.ctrl[:] = self.ctrl_backup
+        self.data.time = self.time_backup
+        mujoco.mj_forward(self.model, self.data)
+
+
+@dataclass
+class KinematicForceData:
+    """Container for kinematic-dependent forces at a single time point."""
+
+    time: float
+    coriolis_forces: np.ndarray
+    gravity_forces: np.ndarray
+    centrifugal_forces: np.ndarray | None = None
+    velocity_coupling_forces: np.ndarray | None = None
+    club_head_coriolis_force: np.ndarray | None = None
+    club_head_centrifugal_force: np.ndarray | None = None
+    club_head_apparent_force: np.ndarray | None = None
+    coriolis_power: float = 0.0
+    centrifugal_power: float = 0.0
+    rotational_kinetic_energy: float = 0.0
+    translational_kinetic_energy: float = 0.0

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_diagnostics.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_diagnostics.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from src.shared.python.core.numerical_constants import EPSILON_SINGULARITY_DETECTION
+
+
+def validate_effective_mass_direction(direction: np.ndarray) -> np.ndarray:
+    """Return a normalized direction vector for effective-mass calculations."""
+    direction_norm = np.linalg.norm(direction)
+    if direction_norm < EPSILON_SINGULARITY_DETECTION:
+        raise ValueError(
+            f"Direction vector has near-zero magnitude: {direction_norm:.2e}. "
+            "Cannot compute effective mass for zero-length direction."
+        )
+    return direction / direction_norm
+
+
+def check_mass_matrix_conditioning(M: np.ndarray) -> None:
+    """Warn or fail when the mass matrix is numerically unsafe."""
+    M_cond = np.linalg.cond(M)
+    if M_cond > 1e6:
+        warnings.warn(
+            f"Mass matrix is ill-conditioned: k(M) = {M_cond:.2e} > 1e6. "
+            "Effective mass computation may be numerically unstable. "
+            "This often indicates the robot is near a kinematic singularity.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+
+    eigenvalues = np.linalg.eigvalsh(M)
+    if np.any(eigenvalues <= 0):
+        raise ValueError(
+            "Mass matrix is not positive definite. "
+            f"Minimum eigenvalue: {eigenvalues.min():.2e}. "
+            "This indicates a modeling error or numerical instability."
+        )
+
+
+def check_jacobian_rank(jacp: np.ndarray) -> None:
+    """Warn when the translational Jacobian loses rank."""
+    jacobian_rank = np.linalg.matrix_rank(jacp)
+    if jacobian_rank < 3:
+        warnings.warn(
+            f"Jacobian is rank deficient: rank={jacobian_rank} < 3. "
+            "Robot has lost mobility in some directions. "
+            "Effective mass may not be well-defined.",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def compute_effective_mass_value(
+    direction: np.ndarray,
+    jacp: np.ndarray,
+    mass_matrix: np.ndarray,
+) -> float:
+    """Compute scalar effective mass along a normalized direction."""
+    directed_jacobian = direction @ jacp
+    mass_matrix_inverse = np.linalg.inv(mass_matrix)
+    denominator = (
+        directed_jacobian @ mass_matrix_inverse @ directed_jacobian.T
+        + EPSILON_SINGULARITY_DETECTION
+    )
+
+    if abs(denominator) < 1e-8:
+        warnings.warn(
+            f"Effective mass denominator near zero: {denominator:.2e}. "
+            "Robot is at or very close to a kinematic singularity in the "
+            f"specified direction {direction}. Effective mass is extremely large.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+
+    effective_mass = 1.0 / denominator
+
+    if effective_mass < 0:
+        raise ValueError(
+            f"Computed negative effective mass: {effective_mass:.2e} kg. "
+            "This indicates a numerical error or modeling issue."
+        )
+
+    if not np.isfinite(effective_mass):
+        warnings.warn(
+            f"Effective mass is non-finite: {effective_mass}. "
+            "Robot is at a kinematic singularity. "
+            "Returning large finite value instead.",
+            category=UserWarning,
+            stacklevel=2,
+        )
+        effective_mass = 1e10
+
+    return float(effective_mass)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_export.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_export.py
@@ -5,74 +5,76 @@ import csv
 from ._kinematic_force_context import KinematicForceData
 
 
+def _build_export_header(nv: int) -> list[str]:
+    header = [
+        "time",
+        "coriolis_power",
+        "centrifugal_power",
+        "rotational_ke",
+        "translational_ke",
+    ]
+    for index in range(nv):
+        header.extend(
+            [
+                f"coriolis_force_{index}",
+                f"gravity_force_{index}",
+                f"centrifugal_force_{index}",
+            ]
+        )
+    header.extend(
+        [
+            "club_coriolis_x",
+            "club_coriolis_y",
+            "club_coriolis_z",
+            "club_centrifugal_x",
+            "club_centrifugal_y",
+            "club_centrifugal_z",
+        ]
+    )
+    return header
+
+
+def _build_force_data_row(force_data: KinematicForceData, nv: int) -> list[float]:
+    row = [
+        force_data.time,
+        force_data.coriolis_power,
+        force_data.centrifugal_power,
+        force_data.rotational_kinetic_energy,
+        force_data.translational_kinetic_energy,
+    ]
+    for index in range(nv):
+        row.extend(
+            [
+                force_data.coriolis_forces[index],
+                force_data.gravity_forces[index],
+                (
+                    force_data.centrifugal_forces[index]
+                    if force_data.centrifugal_forces is not None
+                    else 0.0
+                ),
+            ]
+        )
+    row.extend(
+        force_data.club_head_coriolis_force.tolist()
+        if force_data.club_head_coriolis_force is not None
+        else [0.0, 0.0, 0.0]
+    )
+    row.extend(
+        force_data.club_head_centrifugal_force.tolist()
+        if force_data.club_head_centrifugal_force is not None
+        else [0.0, 0.0, 0.0]
+    )
+    return row
+
+
 def export_kinematic_forces_to_csv(
     force_data_list: list[KinematicForceData],
     filepath: str,
 ) -> None:
     """Export kinematic force analysis to CSV file."""
+    nv = len(force_data_list[0].coriolis_forces)
     with open(filepath, "w", newline="") as file_obj:
         writer = csv.writer(file_obj)
-
-        header = [
-            "time",
-            "coriolis_power",
-            "centrifugal_power",
-            "rotational_ke",
-            "translational_ke",
-        ]
-
-        nv = len(force_data_list[0].coriolis_forces)
-        for index in range(nv):
-            header.extend(
-                [
-                    f"coriolis_force_{index}",
-                    f"gravity_force_{index}",
-                    f"centrifugal_force_{index}",
-                ]
-            )
-
-        header.extend(
-            [
-                "club_coriolis_x",
-                "club_coriolis_y",
-                "club_coriolis_z",
-                "club_centrifugal_x",
-                "club_centrifugal_y",
-                "club_centrifugal_z",
-            ]
-        )
-        writer.writerow(header)
-
+        writer.writerow(_build_export_header(nv))
         for force_data in force_data_list:
-            row = [
-                force_data.time,
-                force_data.coriolis_power,
-                force_data.centrifugal_power,
-                force_data.rotational_kinetic_energy,
-                force_data.translational_kinetic_energy,
-            ]
-
-            for index in range(nv):
-                row.extend(
-                    [
-                        force_data.coriolis_forces[index],
-                        force_data.gravity_forces[index],
-                        (
-                            force_data.centrifugal_forces[index]
-                            if force_data.centrifugal_forces is not None
-                            else 0.0
-                        ),
-                    ]
-                )
-
-            if force_data.club_head_coriolis_force is not None:
-                row.extend(force_data.club_head_coriolis_force.tolist())
-            else:
-                row.extend([0, 0, 0])
-
-            if force_data.club_head_centrifugal_force is not None:
-                row.extend(force_data.club_head_centrifugal_force.tolist())
-            else:
-                row.extend([0, 0, 0])
-
-            writer.writerow(row)
+            writer.writerow(_build_force_data_row(force_data, nv))

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_export.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_export.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import csv
+
+from ._kinematic_force_context import KinematicForceData
+
+
+def export_kinematic_forces_to_csv(
+    force_data_list: list[KinematicForceData],
+    filepath: str,
+) -> None:
+    """Export kinematic force analysis to CSV file."""
+    with open(filepath, "w", newline="") as file_obj:
+        writer = csv.writer(file_obj)
+
+        header = [
+            "time",
+            "coriolis_power",
+            "centrifugal_power",
+            "rotational_ke",
+            "translational_ke",
+        ]
+
+        nv = len(force_data_list[0].coriolis_forces)
+        for index in range(nv):
+            header.extend(
+                [
+                    f"coriolis_force_{index}",
+                    f"gravity_force_{index}",
+                    f"centrifugal_force_{index}",
+                ]
+            )
+
+        header.extend(
+            [
+                "club_coriolis_x",
+                "club_coriolis_y",
+                "club_coriolis_z",
+                "club_centrifugal_x",
+                "club_centrifugal_y",
+                "club_centrifugal_z",
+            ]
+        )
+        writer.writerow(header)
+
+        for force_data in force_data_list:
+            row = [
+                force_data.time,
+                force_data.coriolis_power,
+                force_data.centrifugal_power,
+                force_data.rotational_kinetic_energy,
+                force_data.translational_kinetic_energy,
+            ]
+
+            for index in range(nv):
+                row.extend(
+                    [
+                        force_data.coriolis_forces[index],
+                        force_data.gravity_forces[index],
+                        (
+                            force_data.centrifugal_forces[index]
+                            if force_data.centrifugal_forces is not None
+                            else 0.0
+                        ),
+                    ]
+                )
+
+            if force_data.club_head_coriolis_force is not None:
+                row.extend(force_data.club_head_coriolis_force.tolist())
+            else:
+                row.extend([0, 0, 0])
+
+            if force_data.club_head_centrifugal_force is not None:
+                row.extend(force_data.club_head_centrifugal_force.tolist())
+            else:
+                row.extend([0, 0, 0])
+
+            writer.writerow(row)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_jacobians.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/_kinematic_force_jacobians.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+
+
+def find_body_id(model: mujoco.MjModel, name_pattern: str) -> int | None:
+    """Find body ID by name pattern."""
+    if not (name_pattern is not None):
+        raise ValueError("name_pattern must be provided")
+    for body_index in range(model.nbody):
+        body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, body_index)
+        if body_name and name_pattern.lower() in body_name.lower():
+            return body_index
+    return None
+
+
+def initialize_jacobian_buffers(
+    model: mujoco.MjModel, data: mujoco.MjData
+) -> tuple[bool, np.ndarray, np.ndarray]:
+    """Allocate Jacobian buffers matching the active MuJoCo API."""
+    nv = model.nv
+    try:
+        jacp = np.zeros((3, nv))
+        jacr = np.zeros((3, nv))
+        mujoco.mj_jacBody(model, data, jacp, jacr, 0)
+        return True, jacp, jacr
+    except TypeError:
+        return False, np.zeros(3 * nv), np.zeros(3 * nv)
+
+
+def compute_body_jacobian(
+    model: mujoco.MjModel,
+    data: mujoco.MjData,
+    body_id: int,
+    jacp_buffer: np.ndarray,
+    jacr_buffer: np.ndarray,
+    use_reshaped_arrays: bool,
+    nv: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute a body's translational and rotational Jacobians."""
+    if not (body_id is not None):
+        raise ValueError("body_id must be provided")
+
+    mujoco.mj_jacBody(model, data, jacp_buffer, jacr_buffer, body_id)
+    if use_reshaped_arrays:
+        return jacp_buffer, jacr_buffer
+    return jacp_buffer.reshape(3, nv), jacr_buffer.reshape(3, nv)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
@@ -240,8 +240,8 @@ class KinematicForceAnalyzer:
         # Pre-allocate Jacobian buffers to avoid repeated allocation
         # Detect API version to use correct array shape
         self.nv = model.nv
-        self._use_reshaped_arrays, self._jacp, self._jacr = (
-            initialize_jacobian_buffers(model, data)
+        self._use_reshaped_arrays, self._jacp, self._jacr = initialize_jacobian_buffers(
+            model, data
         )
 
     def _find_body_id(self, name_pattern: str) -> int | None:

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
@@ -150,6 +150,11 @@ from __future__ import annotations
 import mujoco
 import numpy as np
 
+from src.shared.python.core.numerical_constants import (
+    EPSILON_FINITE_DIFF_JACOBIAN,
+    EPSILON_SINGULARITY_DETECTION,
+)
+
 from ._kinematic_force_context import (
     KinematicForceData,
     MjDataContext,
@@ -168,11 +173,12 @@ from ._kinematic_force_jacobians import (
     initialize_jacobian_buffers,
 )
 
-# Import numerical constants (Assessment B-004, B-007)
-from src.shared.python.core.numerical_constants import (
-    EPSILON_FINITE_DIFF_JACOBIAN,
-    EPSILON_SINGULARITY_DETECTION,
-)
+__all__ = [
+    "KinematicForceAnalyzer",
+    "KinematicForceData",
+    "MjDataContext",
+    "export_kinematic_forces_to_csv",
+]
 
 
 # Validate MuJoCo version on module import (Issue F-003)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
@@ -147,13 +147,26 @@ REFERENCES
 
 from __future__ import annotations
 
-import csv
-import warnings
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
 import mujoco
 import numpy as np
+
+from ._kinematic_force_context import (
+    KinematicForceData,
+    MjDataContext,
+    check_mujoco_version,
+)
+from ._kinematic_force_diagnostics import (
+    check_jacobian_rank,
+    check_mass_matrix_conditioning,
+    compute_effective_mass_value,
+    validate_effective_mass_direction,
+)
+from ._kinematic_force_export import export_kinematic_forces_to_csv
+from ._kinematic_force_jacobians import (
+    compute_body_jacobian,
+    find_body_id,
+    initialize_jacobian_buffers,
+)
 
 # Import numerical constants (Assessment B-004, B-007)
 from src.shared.python.core.numerical_constants import (
@@ -161,159 +174,9 @@ from src.shared.python.core.numerical_constants import (
     EPSILON_SINGULARITY_DETECTION,
 )
 
-if TYPE_CHECKING:
-    from types import TracebackType
-
-
-def _check_mujoco_version() -> None:
-    """Validate MuJoCo version meets minimum requirements.
-
-    Addresses Issue F-003: Prevents API signature mismatches by enforcing
-    minimum version at runtime.
-
-    Raises:
-        ImportError: If MuJoCo version is too old
-    """
-    try:
-        # MuJoCo version format: "3.3.0" or similar
-        version_str = mujoco.__version__
-        major, minor, *_ = map(int, version_str.split("."))
-
-        # Require MuJoCo 3.3+ for reshaped Jacobian API
-        if (major, minor) < (3, 3):
-            msg = (
-                f"MuJoCo {version_str} detected, but 3.3.0+ is required.\n"
-                f"The reshaped Jacobian API (mj_jacBody with 2D arrays) was "
-                f"introduced in MuJoCo 3.3. Earlier versions use flat arrays "
-                f"which can cause dimension alignment errors.\n"
-                f"Please upgrade: pip install 'mujoco>=3.3.0,<4.0.0'\n"
-                f"See Issue F-003 in Assessment C for details."
-            )
-            raise ImportError(msg)
-
-        # Success - log version
-        # Success - log version
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.info(f"MuJoCo version {version_str} validated successfully")
-
-    except (AttributeError, ValueError) as e:
-        # Could not parse version
-        warnings.warn(
-            f"Could not validate MuJoCo version: {e}. "
-            f"Proceeding with fallback Jacobian handling.",
-            category=UserWarning,
-            stacklevel=2,
-        )
-
 
 # Validate MuJoCo version on module import (Issue F-003)
-_check_mujoco_version()
-
-
-class MjDataContext:
-    """Context manager for safe MuJoCo MjData state isolation.
-
-    This context manager saves the current state of MjData on entry and
-    restores it on exit, ensuring that any mutations within the context
-    do not affect the original state.
-
-    Addresses Issues A-001, A-003, F-001, F-002 by providing functional
-    purity guarantees for analysis methods.
-
-    Example:
-        >>> with MjDataContext(model, data):
-        ...     data.qpos[:] = new_positions  # Safe to mutate
-        ...     result = compute_something(model, data)
-        ... # data.qpos is automatically restored here
-
-    This enables:
-    - Safe parallel analysis
-    - No Observer Effect bugs
-    - Scientific reproducibility
-    - Thread-safe computations
-    """
-
-    def __init__(self, model: mujoco.MjModel, data: mujoco.MjData) -> None:
-        """Initialize context manager.
-
-        Args:
-            model: MuJoCo model (needed for forward kinematics)
-            data: MuJoCo data structure to protect
-        """
-        if not (model is not None):
-            raise ValueError("model must be provided")
-        self.model = model
-        self.data = data
-        self.qpos_backup: np.ndarray | None = None
-        self.qvel_backup: np.ndarray | None = None
-        self.qacc_backup: np.ndarray | None = None
-        self.ctrl_backup: np.ndarray | None = None
-        self.time_backup: float = 0.0
-
-    def __enter__(self) -> mujoco.MjData:
-        """Save current state on context entry.
-
-        Returns:
-            The data object for convenience
-        """
-        self.qpos_backup = self.data.qpos.copy()
-        self.qvel_backup = self.data.qvel.copy()
-        self.qacc_backup = self.data.qacc.copy()
-        self.ctrl_backup = self.data.ctrl.copy()
-        self.time_backup = self.data.time
-        return self.data
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Restore state on context exit, even if exception occurred.
-
-        Args:
-            exc_type: Exception type if raised
-            exc_val: Exception value if raised
-            exc_tb: Exception traceback if raised
-        """
-        self.data.qpos[:] = self.qpos_backup
-        self.data.qvel[:] = self.qvel_backup
-        self.data.qacc[:] = self.qacc_backup
-        self.data.ctrl[:] = self.ctrl_backup
-        self.data.time = self.time_backup
-
-        # Recompute forward kinematics to sync all derived quantities
-        mujoco.mj_forward(self.model, self.data)
-
-
-@dataclass
-class KinematicForceData:
-    """Container for kinematic-dependent forces at a single time point."""
-
-    time: float
-
-    # Joint-space forces
-    coriolis_forces: np.ndarray  # [nv] - Coriolis and centrifugal forces
-    gravity_forces: np.ndarray  # [nv] - Gravitational forces
-
-    # Decomposed components
-    centrifugal_forces: np.ndarray | None = None  # [nv] - Pure centrifugal
-    velocity_coupling_forces: np.ndarray | None = None  # [nv] - Velocity coupling
-
-    # Task-space forces (end-effector)
-    club_head_coriolis_force: np.ndarray | None = None  # [3] - at club head
-    club_head_centrifugal_force: np.ndarray | None = None  # [3] - at club head
-    club_head_apparent_force: np.ndarray | None = None  # [3] - total apparent force
-
-    # Power contributions
-    coriolis_power: float = 0.0  # Power dissipated by Coriolis forces
-    centrifugal_power: float = 0.0  # Power from centrifugal effects
-
-    # Kinetic energy contributions
-    rotational_kinetic_energy: float = 0.0
-    translational_kinetic_energy: float = 0.0
+check_mujoco_version()
 
 
 class KinematicForceAnalyzer:
@@ -371,29 +234,13 @@ class KinematicForceAnalyzer:
         # Pre-allocate Jacobian buffers to avoid repeated allocation
         # Detect API version to use correct array shape
         self.nv = model.nv
-        try:
-            # Try reshaped API (MuJoCo 3.3+ preferred)
-            jacp_test = np.zeros((3, self.nv))
-            jacr_test = np.zeros((3, self.nv))
-            mujoco.mj_jacBody(model, data, jacp_test, jacr_test, 0)
-            self._use_reshaped_arrays = True
-            self._jacp = np.zeros((3, self.nv))
-            self._jacr = np.zeros((3, self.nv))
-        except TypeError:
-            # Fallback to flat API
-            self._use_reshaped_arrays = False
-            self._jacp = np.zeros(3 * self.nv)
-            self._jacr = np.zeros(3 * self.nv)
+        self._use_reshaped_arrays, self._jacp, self._jacr = (
+            initialize_jacobian_buffers(model, data)
+        )
 
     def _find_body_id(self, name_pattern: str) -> int | None:
         """Find body ID by name pattern."""
-        if not (name_pattern is not None):
-            raise ValueError("name_pattern must be provided")
-        for i in range(self.model.nbody):
-            body_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, i)
-            if body_name and name_pattern.lower() in body_name.lower():
-                return i
-        return None
+        return find_body_id(self.model, name_pattern)
 
     def _compute_jacobian(
         self, body_id: int, data: mujoco.MjData | None = None
@@ -413,15 +260,15 @@ class KinematicForceAnalyzer:
         if data is None:
             data = self.data
 
-        if self._use_reshaped_arrays:
-            mujoco.mj_jacBody(self.model, data, self._jacp, self._jacr, body_id)
-            return self._jacp, self._jacr
-        else:
-            mujoco.mj_jacBody(self.model, data, self._jacp, self._jacr, body_id)
-            return (
-                self._jacp.reshape(3, self.nv),
-                self._jacr.reshape(3, self.nv),
-            )
+        return compute_body_jacobian(
+            self.model,
+            data,
+            body_id,
+            self._jacp,
+            self._jacr,
+            self._use_reshaped_arrays,
+            self.nv,
+        )
 
     def compute_coriolis_forces(self, qpos: np.ndarray, qvel: np.ndarray) -> np.ndarray:
         """Compute Coriolis and centrifugal forces.
@@ -871,79 +718,18 @@ class KinematicForceAnalyzer:
         return results
 
     def _validate_effective_mass_direction(self, direction: np.ndarray) -> np.ndarray:
-        direction_norm = np.linalg.norm(direction)
-        if direction_norm < EPSILON_SINGULARITY_DETECTION:
-            raise ValueError(
-                f"Direction vector has near-zero magnitude: {direction_norm:.2e}. "
-                "Cannot compute effective mass for zero-length direction."
-            )
-        return direction / direction_norm
+        return validate_effective_mass_direction(direction)
 
     def _check_mass_matrix_conditioning(self, M: np.ndarray) -> None:
-        M_cond = np.linalg.cond(M)
-        if M_cond > 1e6:
-            warnings.warn(
-                f"Mass matrix is ill-conditioned: κ(M) = {M_cond:.2e} > 1e6. "
-                "Effective mass computation may be numerically unstable. "
-                "This often indicates the robot is near a kinematic singularity.",
-                category=UserWarning,
-                stacklevel=2,
-            )
-
-        eigenvalues = np.linalg.eigvalsh(M)
-        if np.any(eigenvalues <= 0):
-            raise ValueError(
-                f"Mass matrix is not positive definite. "
-                f"Minimum eigenvalue: {eigenvalues.min():.2e}. "
-                "This indicates a modeling error or numerical instability."
-            )
+        check_mass_matrix_conditioning(M)
 
     def _check_jacobian_rank(self, jacp: np.ndarray) -> None:
-        J_rank = np.linalg.matrix_rank(jacp)
-        if J_rank < 3:
-            warnings.warn(
-                f"Jacobian is rank deficient: rank={J_rank} < 3. "
-                "Robot has lost mobility in some directions. "
-                "Effective mass may not be well-defined.",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
+        check_jacobian_rank(jacp)
 
     def _compute_effective_mass_value(
         self, direction: np.ndarray, jacp: np.ndarray, M: np.ndarray
     ) -> float:
-        J_dir = direction @ jacp
-        M_inv = np.linalg.inv(M)
-        denominator = J_dir @ M_inv @ J_dir.T + EPSILON_SINGULARITY_DETECTION
-
-        if abs(denominator) < 1e-8:
-            warnings.warn(
-                f"Effective mass denominator near zero: {denominator:.2e}. "
-                "Robot is at or very close to a kinematic singularity in the "
-                f"specified direction {direction}. Effective mass is extremely large.",
-                category=UserWarning,
-                stacklevel=2,
-            )
-
-        m_eff = 1.0 / denominator
-
-        if m_eff < 0:
-            raise ValueError(
-                f"Computed negative effective mass: {m_eff:.2e} kg. "
-                "This indicates a numerical error or modeling issue."
-            )
-
-        if not np.isfinite(m_eff):
-            warnings.warn(
-                f"Effective mass is non-finite: {m_eff}. "
-                "Robot is at a kinematic singularity. "
-                "Returning large finite value instead.",
-                category=UserWarning,
-                stacklevel=2,
-            )
-            m_eff = 1e10
-
-        return float(m_eff)
+        return compute_effective_mass_value(direction, jacp, M)
 
     def compute_effective_mass(
         self,
@@ -1021,82 +807,3 @@ class KinematicForceAnalyzer:
         self._check_jacobian_rank(jacp)
 
         return self._compute_effective_mass_value(direction, jacp, M)
-
-
-def export_kinematic_forces_to_csv(
-    force_data_list: list[KinematicForceData],
-    filepath: str,
-) -> None:
-    """Export kinematic force analysis to CSV file.
-
-    Args:
-        force_data_list: List of force data
-        filepath: Output CSV file path
-    """
-    with open(filepath, "w", newline="") as f:
-        writer = csv.writer(f)
-
-        # Header
-        header = [
-            "time",
-            "coriolis_power",
-            "centrifugal_power",
-            "rotational_ke",
-            "translational_ke",
-        ]
-
-        # Add joint-wise Coriolis forces
-        nv = len(force_data_list[0].coriolis_forces)
-        for i in range(nv):
-            header.extend(
-                [f"coriolis_force_{i}", f"gravity_force_{i}", f"centrifugal_force_{i}"],
-            )
-
-        # Add club head forces
-        header.extend(
-            [
-                "club_coriolis_x",
-                "club_coriolis_y",
-                "club_coriolis_z",
-                "club_centrifugal_x",
-                "club_centrifugal_y",
-                "club_centrifugal_z",
-            ],
-        )
-
-        writer.writerow(header)
-
-        # Data rows
-        for data in force_data_list:
-            row = [
-                data.time,
-                data.coriolis_power,
-                data.centrifugal_power,
-                data.rotational_kinetic_energy,
-                data.translational_kinetic_energy,
-            ]
-
-            for i in range(nv):
-                row.extend(
-                    [
-                        data.coriolis_forces[i],
-                        data.gravity_forces[i],
-                        (
-                            data.centrifugal_forces[i]
-                            if data.centrifugal_forces is not None
-                            else 0.0
-                        ),
-                    ],
-                )
-
-            if data.club_head_coriolis_force is not None:
-                row.extend(data.club_head_coriolis_force.tolist())
-            else:
-                row.extend([0, 0, 0])
-
-            if data.club_head_centrifugal_force is not None:
-                row.extend(data.club_head_centrifugal_force.tolist())
-            else:
-                row.extend([0, 0, 0])
-
-            writer.writerow(row)

--- a/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
+++ b/src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf/kinematic_forces.py
@@ -360,67 +360,30 @@ class KinematicForceAnalyzer:
         # With zero velocity, qfrc_bias = g(q)
         return np.asarray(self._perturb_data.qfrc_bias.copy())
 
+    def _compute_single_axis_coriolis(
+        self, qpos: np.ndarray, qvel: np.ndarray, axis_index: int
+    ) -> np.ndarray:
+        qvel_single = np.zeros(self.model.nv)
+        qvel_single[axis_index] = qvel[axis_index]
+        return self.compute_coriolis_forces(qpos, qvel_single)
+
     def decompose_coriolis_forces(
         self,
         qpos: np.ndarray,
         qvel: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray]:
-        """Decompose Coriolis forces into centrifugal and velocity coupling.
-
-            Coriolis matrix C(q,q̇) can be decomposed:
-            - Centrifugal terms: Diagonal terms (q̇ᵢ²)
-            - Velocity coupling: Off-diagonal terms (q̇ᵢq̇ⱼ)
-
-            ⚠️ PERFORMANCE NOTE (Phase 1 Implemented):
-        This method iterates N times to separate diagonal vs off-diagonal terms.
-        However, the inner calculation now uses Analytical RNE (`mj_rne`),
-        which is significantly faster than the legacy `mj_forward` approach.
-        Global complexity is O(N^2) but with a much smaller constant factor.
-
-            RECOMMENDATION: Use the combined compute_coriolis_forces() method instead,
-            which returns the total Coriolis+centrifugal forces efficiently in O(N).
-            Decomposition is rarely needed for most applications.
-
-            See Issue A-002 and B-002 for optimization path using analytical RNE.
-
-            Args:
-                qpos: Joint positions [nv]
-                qvel: Joint velocities [nv]
-
-            Returns:
-                Tuple of (centrifugal_forces [nv], coupling_forces [nv])
-        """
-        # OPTIMIZATION NOTE: The proper fix is to use mj_rne properties or
-        # implement analytical decomposition. Current implementation is
-        # accurate but slow for high-DOF systems.
-        #
-        # Full analytical solution requires:
-        # - Custom RNE recursion to separate diagonal/off-diagonal terms
-        # - OR use spatial algebra (screw theory) for frame-independent decomposition
-        # - OR skip decomposition and use total Coriolis forces directly
-        #
-        # For most golf swing analyses, the total Coriolis force is sufficient.
-
+        """Split Coriolis forces into diagonal and coupling contributions."""
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
-        centrifugal = np.zeros(self.model.nv)
-        coupling = np.zeros(self.model.nv)
-
-        # Full Coriolis forces
         total_coriolis = self.compute_coriolis_forces(qpos, qvel)
-
-        # Estimate centrifugal: vary each velocity independently
-        # This captures diagonal terms of the Coriolis matrix
-        for i in range(self.model.nv):
-            qvel_single = np.zeros(self.model.nv)
-            qvel_single[i] = qvel[i]
-
-            single_coriolis = self.compute_coriolis_forces(qpos, qvel_single)
-            centrifugal += single_coriolis
-
-        # Coupling is the difference (off-diagonal terms)
+        centrifugal = sum(
+            (
+                self._compute_single_axis_coriolis(qpos, qvel, axis_index)
+                for axis_index in range(self.model.nv)
+            ),
+            start=np.zeros(self.model.nv),
+        )
         coupling = total_coriolis - centrifugal
-
         return centrifugal, coupling
 
     def compute_mass_matrix(self, qpos: np.ndarray) -> np.ndarray:
@@ -484,91 +447,19 @@ class KinematicForceAnalyzer:
         qvel: np.ndarray,
         qacc: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Compute apparent forces at club head (Coriolis, centrifugal, etc.).
-
-        These are the "fictitious" forces experienced in the rotating
-        reference frame attached to the golfer.
-
-        FIXED: Uses dedicated _perturb_data to prevent state corruption.
-
-        Args:
-            qpos: Joint positions [nv]
-            qvel: Joint velocities [nv]
-            qacc: Joint accelerations [nv]
-
-        Returns:
-            Tuple of (coriolis_force [3], centrifugal_force [3], total_apparent [3])
-        """
+        """Compute apparent club-head forces from the current kinematic state."""
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
         if self.club_head_id is None:
             return np.zeros(3), np.zeros(3), np.zeros(3)
-
-        # FIXED: Use private data structure for current state
-        self._perturb_data.qpos[:] = qpos
-        self._perturb_data.qvel[:] = qvel
-        mujoco.mj_forward(self.model, self._perturb_data)
-
-        # Compute club head Jacobian
-        jacp, _ = self._compute_jacobian(self.club_head_id, data=self._perturb_data)
-        jacp_curr = jacp.copy()  # Save copy as _compute_jacobian reuses buffer
-
-        # Store club position before perturbing state
-        club_pos = self._perturb_data.xpos[self.club_head_id].copy()
-
-        # Jacobian time derivative (approximate)
-        # ASSESSMENT B-009: Use second-order central difference for improved accuracy
-        # Central difference: J̇ ≈ (J(q+εq̇) - J(q-εq̇)) / (2ε)
-        # Error: O(ε²) vs O(ε) for forward difference
-        epsilon = EPSILON_FINITE_DIFF_JACOBIAN
-
-        # Compute Jacobian at forward-perturbed state
-        self._perturb_data.qpos[:] = qpos + epsilon * qvel
-        self._perturb_data.qvel[:] = qvel
-        mujoco.mj_forward(self.model, self._perturb_data)
-
-        jacp_forward, _ = self._compute_jacobian(
-            self.club_head_id, data=self._perturb_data
-        )  # noqa: E501
-        jacp_forward = jacp_forward.copy()  # Save copy before buffer reuse
-
-        # Compute Jacobian at backward-perturbed state
-        self._perturb_data.qpos[:] = qpos - epsilon * qvel
-        self._perturb_data.qvel[:] = qvel
-        mujoco.mj_forward(self.model, self._perturb_data)
-
-        jacp_backward, _ = self._compute_jacobian(
-            self.club_head_id, data=self._perturb_data
-        )  # noqa: E501
-
-        # Second-order central difference
-        # Accuracy: O(ε²) - much better than O(ε) forward difference
-        jacp_dot = (jacp_forward - jacp_backward) / (2.0 * epsilon)
-
-        # Coriolis force: -2m(Ω × v)
-        # In our case: Coriolis contribution to acceleration
+        jacp_curr, club_pos = self._compute_club_head_state(qpos, qvel)
+        jacp_dot = self._compute_club_head_jacobian_time_derivative(qpos, qvel)
         coriolis_accel = jacp_dot @ qvel
-
-        # Assume unit mass for force (or multiply by club head mass)
         club_head_mass = self.model.body_mass[self.club_head_id]
         coriolis_force = -club_head_mass * coriolis_accel
-
-        # Centrifugal force: -mΩ²r
-        # This is embedded in the Coriolis term
-        # For separation, we'd need angular velocity of each body segment
-
-        # Total apparent force (from joint-space Coriolis forces)
         joint_coriolis = self.compute_coriolis_forces(qpos, qvel)
         apparent_force = jacp_curr.T @ joint_coriolis[: self.model.nv]
-
-        # Approximate centrifugal as component aligned with position
-        # Singularity protection when near origin
-        centrifugal_direction = club_pos / (
-            np.linalg.norm(club_pos) + EPSILON_SINGULARITY_DETECTION
-        )
-        centrifugal_magnitude = np.dot(apparent_force, centrifugal_direction)
-        centrifugal_force = centrifugal_magnitude * centrifugal_direction
-
+        centrifugal_force = self._compute_centrifugal_force(apparent_force, club_pos)
         return coriolis_force, centrifugal_force, apparent_force
 
     def compute_kinematic_power(
@@ -680,48 +571,15 @@ class KinematicForceAnalyzer:
         """
         if not (times is not None):
             raise ValueError("times must be provided")
-        results = []
-
-        for i in range(len(times)):
-            qpos = positions[i]
-            qvel = velocities[i]
-            qacc = accelerations[i]
-
-            # Compute forces
-            coriolis = self.compute_coriolis_forces(qpos, qvel)
-            gravity = self.compute_gravity_forces(qpos)
-            centrifugal, coupling = self.decompose_coriolis_forces(qpos, qvel)
-
-            # Club head apparent forces
-            club_coriolis, club_centrifugal, club_apparent = (
-                self.compute_club_head_apparent_forces(qpos, qvel, qacc)
-            )  # noqa: E501
-
-            # Power contributions
-            power_dict = self.compute_kinematic_power(qpos, qvel)
-
-            # Kinetic energy
-            ke_dict = self.compute_kinetic_energy_components(qpos, qvel)
-
-            # Create data object
-            data = KinematicForceData(
-                time=times[i],
-                coriolis_forces=coriolis,
-                gravity_forces=gravity,
-                centrifugal_forces=centrifugal,
-                velocity_coupling_forces=coupling,
-                club_head_coriolis_force=club_coriolis,
-                club_head_centrifugal_force=club_centrifugal,
-                club_head_apparent_force=club_apparent,
-                coriolis_power=power_dict["coriolis_power"],
-                centrifugal_power=power_dict["centrifugal_power"],
-                rotational_kinetic_energy=ke_dict["rotational"],
-                translational_kinetic_energy=ke_dict["translational"],
+        return [
+            self._analyze_trajectory_step(
+                times[index],
+                positions[index],
+                velocities[index],
+                accelerations[index],
             )
-
-            results.append(data)
-
-        return results
+            for index in range(len(times))
+        ]
 
     def _validate_effective_mass_direction(self, direction: np.ndarray) -> np.ndarray:
         return validate_effective_mass_direction(direction)
@@ -737,79 +595,94 @@ class KinematicForceAnalyzer:
     ) -> float:
         return compute_effective_mass_value(direction, jacp, M)
 
+    def _compute_club_head_state(
+        self, qpos: np.ndarray, qvel: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        self._perturb_data.qpos[:] = qpos
+        self._perturb_data.qvel[:] = qvel
+        mujoco.mj_forward(self.model, self._perturb_data)
+        jacp, _ = self._compute_jacobian(self.club_head_id, data=self._perturb_data)
+        return jacp.copy(), self._perturb_data.xpos[self.club_head_id].copy()
+
+    def _compute_club_head_jacobian_time_derivative(
+        self, qpos: np.ndarray, qvel: np.ndarray
+    ) -> np.ndarray:
+        epsilon = EPSILON_FINITE_DIFF_JACOBIAN
+        self._perturb_data.qpos[:] = qpos + epsilon * qvel
+        self._perturb_data.qvel[:] = qvel
+        mujoco.mj_forward(self.model, self._perturb_data)
+        jacp_forward, _ = self._compute_jacobian(
+            self.club_head_id, data=self._perturb_data
+        )
+        self._perturb_data.qpos[:] = qpos - epsilon * qvel
+        self._perturb_data.qvel[:] = qvel
+        mujoco.mj_forward(self.model, self._perturb_data)
+        jacp_backward, _ = self._compute_jacobian(
+            self.club_head_id, data=self._perturb_data
+        )
+        return (jacp_forward.copy() - jacp_backward) / (2.0 * epsilon)
+
+    def _compute_centrifugal_force(
+        self, apparent_force: np.ndarray, club_pos: np.ndarray
+    ) -> np.ndarray:
+        centrifugal_direction = club_pos / (
+            np.linalg.norm(club_pos) + EPSILON_SINGULARITY_DETECTION
+        )
+        centrifugal_magnitude = np.dot(apparent_force, centrifugal_direction)
+        return centrifugal_magnitude * centrifugal_direction
+
+    def _analyze_trajectory_step(
+        self, time_value: float, qpos: np.ndarray, qvel: np.ndarray, qacc: np.ndarray
+    ) -> KinematicForceData:
+        coriolis = self.compute_coriolis_forces(qpos, qvel)
+        gravity = self.compute_gravity_forces(qpos)
+        centrifugal, coupling = self.decompose_coriolis_forces(qpos, qvel)
+        club_coriolis, club_centrifugal, club_apparent = (
+            self.compute_club_head_apparent_forces(qpos, qvel, qacc)
+        )
+        power_dict = self.compute_kinematic_power(qpos, qvel)
+        ke_dict = self.compute_kinetic_energy_components(qpos, qvel)
+        return KinematicForceData(
+            time=time_value,
+            coriolis_forces=coriolis,
+            gravity_forces=gravity,
+            centrifugal_forces=centrifugal,
+            velocity_coupling_forces=coupling,
+            club_head_coriolis_force=club_coriolis,
+            club_head_centrifugal_force=club_centrifugal,
+            club_head_apparent_force=club_apparent,
+            coriolis_power=power_dict["coriolis_power"],
+            centrifugal_power=power_dict["centrifugal_power"],
+            rotational_kinetic_energy=ke_dict["rotational"],
+            translational_kinetic_energy=ke_dict["translational"],
+        )
+
+    def _resolve_effective_mass_body_id(self, body_id: int | None) -> int | None:
+        return self.club_head_id if body_id is None else body_id
+
+    def _compute_effective_mass_inputs(
+        self, qpos: np.ndarray, body_id: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        mass_matrix = self.compute_mass_matrix(qpos)
+        self._check_mass_matrix_conditioning(mass_matrix)
+        self._perturb_data.qpos[:] = qpos
+        mujoco.mj_forward(self.model, self._perturb_data)
+        jacp, _ = self._compute_jacobian(body_id, data=self._perturb_data)
+        self._check_jacobian_rank(jacp)
+        return jacp, mass_matrix
+
     def compute_effective_mass(
         self,
         qpos: np.ndarray,
         direction: np.ndarray,
         body_id: int | None = None,
     ) -> float:
-        """Compute effective mass in a given direction.
-
-        Effective mass determines how difficult it is to accelerate
-        in a specific direction. Near kinematic singularities, the
-        effective mass can become very large (approaching infinity).
-
-        NUMERICAL STABILITY (Assessment B-008):
-        ----------------------------------------
-        This method monitors the condition number of the mass matrix
-        and Jacobian to detect approaching singularities. When detected:
-        - Warning issued if condition number > 1e6
-        - Regularization applied automatically
-        - Result validity flag returned
-
-        PHYSICS:
-        --------
-        The effective mass is computed as:
-            m_eff = (J M^{-1} J^T)^{-1}
-
-        Where:
-        - J = Jacobian mapping joint velocities to task-space velocity
-        - M = joint-space mass matrix (configuration-dependent)
-
-        Near singularities:
-        - m_eff → ∞ (infinite mass, cannot accelerate)
-        - Physically meaningful: robot at kinematic boundary
-
-        FIXED: Uses dedicated _perturb_data to prevent state corruption.
-
-        Args:
-            qpos: Joint positions [nv] (rad for revolute, m for prismatic)
-            direction: Direction vector [3] (will be normalized)
-            body_id: Body to compute for (default: club head)
-
-        Returns:
-            Effective mass in that direction [kg]
-
-        Warns:
-            UserWarning: If approaching singularity (condition number > 1e6)
-
-        Raises:
-            ValueError: If mass matrix is not positive definite
-            RuntimeWarning: If Jacobian is rank deficient
-
-        Examples:
-            >>> # Compute effective mass in vertical direction
-            >>> direction = np.array([0, 0, 1])  # Z-up
-            >>> m_eff = analyzer.compute_effective_mass(qpos, direction)
-            >>> print(f"Effective mass: {m_eff:.2f} kg")
-        """
+        """Compute effective mass in a given direction."""
         if not (qpos is not None):
             raise ValueError("qpos must be provided")
-        if body_id is None:
-            body_id = self.club_head_id
-
+        body_id = self._resolve_effective_mass_body_id(body_id)
         if body_id is None:
             return 0.0
-
         direction = self._validate_effective_mass_direction(direction)
-
-        M = self.compute_mass_matrix(qpos)
-        self._check_mass_matrix_conditioning(M)
-
-        self._perturb_data.qpos[:] = qpos
-        mujoco.mj_forward(self.model, self._perturb_data)
-
-        jacp, _ = self._compute_jacobian(body_id, data=self._perturb_data)
-        self._check_jacobian_rank(jacp)
-
-        return self._compute_effective_mass_value(direction, jacp, M)
+        jacp, mass_matrix = self._compute_effective_mass_inputs(qpos, body_id)
+        return self._compute_effective_mass_value(direction, jacp, mass_matrix)

--- a/tests/unit/engines/mujoco/test_kinematic_forces.py
+++ b/tests/unit/engines/mujoco/test_kinematic_forces.py
@@ -1,7 +1,7 @@
 """Comprehensive tests for kinematic forces module."""
 
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import mujoco
 import numpy as np

--- a/tests/unit/engines/mujoco/test_kinematic_forces.py
+++ b/tests/unit/engines/mujoco/test_kinematic_forces.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for kinematic forces module."""
 
+from pathlib import Path
 import warnings
 
 import mujoco
@@ -8,6 +9,8 @@ import pytest
 from mujoco_humanoid_golf.kinematic_forces import (
     KinematicForceAnalyzer,
     KinematicForceData,
+    MjDataContext,
+    export_kinematic_forces_to_csv,
 )
 from mujoco_humanoid_golf.models import DOUBLE_PENDULUM_XML
 
@@ -212,3 +215,46 @@ class TestKinematicForceAnalyzer:
         assert "coriolis_power" in power_data
         assert "centrifugal_power" in power_data
         assert all(isinstance(v, float) for v in power_data.values())
+
+    def test_mj_data_context_restores_state(self, model_and_data) -> None:
+        """Test state isolation contract for temporary MuJoCo mutations."""
+        model, data = model_and_data
+        qpos_before = data.qpos.copy()
+        qvel_before = data.qvel.copy()
+        qacc_before = data.qacc.copy()
+        ctrl_before = data.ctrl.copy()
+        time_before = data.time
+
+        with MjDataContext(model, data):
+            data.qpos[:] = 0.25
+            data.qvel[:] = 0.5
+            data.qacc[:] = 0.75
+            data.ctrl[:] = 0.1
+            data.time = 1.23
+
+        np.testing.assert_array_equal(data.qpos, qpos_before)
+        np.testing.assert_array_equal(data.qvel, qvel_before)
+        np.testing.assert_array_equal(data.qacc, qacc_before)
+        np.testing.assert_array_equal(data.ctrl, ctrl_before)
+        assert data.time == time_before
+
+    def test_export_kinematic_forces_to_csv(self, tmp_path: Path) -> None:
+        """Test CSV export from public facade."""
+        output_path = tmp_path / "kinematic_forces.csv"
+        force_data = [
+            KinematicForceData(
+                time=0.1,
+                coriolis_forces=np.array([1.0, 2.0]),
+                gravity_forces=np.array([3.0, 4.0]),
+                centrifugal_forces=np.array([5.0, 6.0]),
+                club_head_coriolis_force=np.array([0.1, 0.2, 0.3]),
+                club_head_centrifugal_force=np.array([0.4, 0.5, 0.6]),
+            )
+        ]
+
+        export_kinematic_forces_to_csv(force_data, str(output_path))
+
+        csv_text = output_path.read_text()
+        assert "coriolis_force_0" in csv_text
+        assert "club_centrifugal_z" in csv_text
+        assert "0.1" in csv_text


### PR DESCRIPTION
## Summary
- split MuJoCo kinematic-force support code into focused helper modules while keeping the public facade stable
- add regression coverage for the extracted state-isolation and CSV-export seams
- remove inline sys.path shims from the root aerodynamics, flight, and topography demos and switch their docs to module-style execution

## Validation
- python3 -m pytest tests/unit/engines/mujoco/test_kinematic_forces.py -q
- python3 -m compileall src/engines/physics_engines/mujoco/python/mujoco_humanoid_golf examples
- python3 -m examples.aerodynamics_demo
- python3 -m examples.topography_demo

## Notes
- python3 -m examples.basic_flight_simulation still reaches the existing strict Rust parity runtime guard after imports succeed; this change intentionally keeps that behavior unchanged.

Closes #129