### PR TITLE
fix(ci): prevent apt-get locks and block raw conflict markers

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -5,13 +5,19 @@ on:
     paths-ignore:
       - "LICENSE"
       - ".gitignore"
-      - ".github/**"
+      # .github/** is NOT ignored so CI-fix PRs can satisfy required checks
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - ".github/FUNDING.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "LICENSE"
       - ".gitignore"
-      - ".github/**"
+      # .github/** is NOT ignored so CI-fix PRs can satisfy required checks
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - ".github/FUNDING.yml"
   workflow_dispatch:
   schedule:
     # Weekly run every Monday at 06:00 UTC — catches test drift and
@@ -151,7 +157,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Reject Raw Merge Conflict Markers
         run: |
-          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git; then
+          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git --exclude-dir=.github; then
             echo "::error::Raw git merge conflict markers found!"
             exit 1
           fi
@@ -263,7 +269,7 @@ jobs:
         run: bash "$GITHUB_WORKSPACE/scripts/setup_tools_workspace.sh"
       - name: Reject Raw Merge Conflict Markers
         run: |
-          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git; then
+          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git --exclude-dir=.github; then
             echo "::error::Raw git merge conflict markers found!"
             exit 1
           fi

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -149,10 +149,17 @@ jobs:
         python: ["3.11"]
     steps:
       - uses: actions/checkout@v6
+      - name: Reject Raw Merge Conflict Markers
+        run: |
+          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git; then
+            echo "::error::Raw git merge conflict markers found!"
+            exit 1
+          fi
+
       - name: Install System Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             libegl1 libgl1 xvfb \
             libxkbcommon-x11-0 \
             libxcb-cursor0 \
@@ -254,10 +261,17 @@ jobs:
           path: _tools_dep
       - name: Symlink Tools for Workspace
         run: bash "$GITHUB_WORKSPACE/scripts/setup_tools_workspace.sh"
+      - name: Reject Raw Merge Conflict Markers
+        run: |
+          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git; then
+            echo "::error::Raw git merge conflict markers found!"
+            exit 1
+          fi
+
       - name: Install System Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y \
             libegl1 libgl1 xvfb \
             libxkbcommon-x11-0 \
             libxcb-cursor0 \

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -65,8 +65,8 @@ jobs:
 
       - name: Install system display dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get -o DPkg::Lock::Timeout=300 update -qq
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y --no-install-recommends \
             xvfb x11-utils mesa-utils \
             libgl1 libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
             libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 \

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Install Linux dependencies
         run: |
           if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-            sudo apt-get update
-            sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+            sudo apt-get -o DPkg::Lock::Timeout=300 update
+            sudo apt-get -o DPkg::Lock::Timeout=300 install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
           else
             echo "Skipping Linux package install on runners without passwordless sudo"
           fi
@@ -158,8 +158,8 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
         working-directory: ui


### PR DESCRIPTION
Automated infrastructure fix. 1) Adds DPkg::Lock::Timeout=300 to apt-get to gracefully queue against parallel self-hosted runner lock collision, solving the recurring exit code 100 errors. 2) Inserts a pre-flight grep check against raw git conflict markers to instantly fail the gate before broken specs merge into main.