### PR TITLE
refactor(#136): extract MakeHuman mesh generator

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/makehuman_mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/makehuman_mesh_generator.py
@@ -1,0 +1,377 @@
+"""MakeHuman mesh generator for humanoid character builder."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from humanoid_character_builder.core.body_parameters import BodyParameters
+from humanoid_character_builder.generators import mesh_generator as _mg
+from humanoid_character_builder.generators.makehuman_mesh_utils import (
+    MAKEHUMAN_DEFAULT_HEIGHT_M,
+    MAKEHUMAN_SEARCH_PATHS,
+    MAKEHUMAN_SEGMENT_GROUPS,
+    arrays_from_obj_parts,
+    clamp,
+    export_mesh_pair,
+    export_submesh,
+    load_vertex_groups,
+    parse_group_line,
+    parse_obj_line,
+    prepare_output_dirs,
+    script_outputs,
+    segment_by_index_range,
+    segment_z_ranges,
+    slice_mesh_at_z,
+    valid_segments,
+)
+from humanoid_character_builder.generators.mesh_generator import (
+    GeneratedMeshResult,
+    MeshGeneratorInterface,
+)
+from humanoid_character_builder.generators.mesh_invariants import (
+    validate_mesh_invariants,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MakeHumanMeshGenerator(MeshGeneratorInterface):
+    """Generate humanoid body segment meshes using MakeHuman exports."""
+
+    #: Mapping from MakeHuman vertex group names to this package's segment names.
+    #: Each key and value is unique to keep segmentation reversible.
+    MH_VERTEX_GROUP_MAP: dict[str, str] = {
+        key: value
+        for key, value in MAKEHUMAN_SEGMENT_GROUPS.items()
+        if key not in {"upper_torso", "lower_torso"}
+    }
+
+    def __init__(self, makehuman_path: Path | str | None = None) -> None:
+        """Initialize the MakeHuman backend."""
+        self.makehuman_path = Path(makehuman_path) if makehuman_path else None
+
+    @property
+    def backend_name(self) -> str:
+        return "makehuman"
+
+    @property
+    def is_available(self) -> bool:
+        if self.makehuman_path and self.makehuman_path.exists():
+            return True
+        return self._discover_makehuman_path()
+
+    def generate(
+        self,
+        params: BodyParameters,
+        output_dir: Path,
+        **kwargs: Any,
+    ) -> GeneratedMeshResult:
+        """Generate segmented STL meshes using MakeHuman scripted mode."""
+        assert params is not None, "params must be provided"
+        if not self.is_available:
+            return GeneratedMeshResult(
+                success=False,
+                error_message="MakeHuman not found. Please install MakeHuman or provide path.",
+            )
+        visual_dir, collision_dir = prepare_output_dirs(output_dir)
+        modifiers = self._convert_params_to_makehuman(params)
+        try:
+            return self._generate_via_api(
+                modifiers,
+                visual_dir,
+                collision_dir,
+                **kwargs,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning("MakeHuman API generation failed: %s", exc)
+            return GeneratedMeshResult(
+                success=False,
+                error_message=f"MakeHuman generation failed: {exc}",
+            )
+
+    def _discover_makehuman_path(self) -> bool:
+        for path in MAKEHUMAN_SEARCH_PATHS:
+            if path.exists():
+                self.makehuman_path = path
+                return True
+        return False
+
+    def _generate_via_api(
+        self,
+        modifiers: dict[str, float],
+        visual_dir: Path,
+        collision_dir: Path,
+        **kwargs: Any,
+    ) -> GeneratedMeshResult:
+        """Generate meshes by running a temporary MakeHuman script."""
+        del kwargs
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            body_obj, groups_json = script_outputs(tmp)
+            script_path = self._write_makehuman_script(
+                tmp, modifiers, body_obj, groups_json
+            )
+            if not self._run_makehuman_script(script_path):
+                raise RuntimeError("MakeHuman script execution failed")
+            vertex_groups = load_vertex_groups(groups_json)
+            vertices, faces = self._load_body_mesh(body_obj)
+            return self._export_grouped_segments(
+                vertices,
+                faces,
+                vertex_groups,
+                visual_dir,
+                collision_dir,
+            )
+
+    def _load_body_mesh(self, body_obj: Path) -> tuple[np.ndarray, np.ndarray]:
+        if not body_obj.exists():
+            raise RuntimeError(f"MakeHuman did not produce OBJ: {body_obj}")
+        vertices, faces = self._parse_obj_file(body_obj)
+        if len(vertices) == 0:
+            raise RuntimeError("Parsed OBJ has no vertices")
+        if not _mg.TRIMESH_AVAILABLE:
+            raise RuntimeError("trimesh required for mesh segmentation")
+        return vertices, faces
+
+    def _export_grouped_segments(
+        self,
+        vertices: np.ndarray,
+        faces: np.ndarray,
+        vertex_groups: dict[str, list[int]],
+        visual_dir: Path,
+        collision_dir: Path,
+    ) -> GeneratedMeshResult:
+        mesh_paths: dict[str, Path] = {}
+        collision_paths: dict[str, Path] = {}
+        for group_name, segment_name in self.MH_VERTEX_GROUP_MAP.items():
+            indices = vertex_groups.get(group_name, [])
+            segment = segment_by_index_range(vertices, faces, indices)
+            if segment is None:
+                continue
+            self._export_segment(segment, segment_name, visual_dir, collision_dir)
+            mesh_paths[segment_name] = visual_dir / f"{segment_name}.stl"
+            collision_paths[segment_name] = collision_dir / f"{segment_name}.stl"
+        return GeneratedMeshResult(
+            success=bool(mesh_paths),
+            mesh_paths=mesh_paths,
+            collision_paths=collision_paths,
+            vertex_groups=vertex_groups,
+            metadata={"backend": "makehuman"},
+        )
+
+    @staticmethod
+    def _export_segment(
+        segment: tuple[np.ndarray, np.ndarray],
+        segment_name: str,
+        visual_dir: Path,
+        collision_dir: Path,
+    ) -> None:
+        segment_vertices, segment_faces = segment
+        submesh = _mg._trimesh_module.Trimesh(  # type: ignore[union-attr]
+            vertices=segment_vertices,
+            faces=segment_faces,
+        )
+        validate_mesh_invariants(submesh, context=f"MakeHuman {segment_name}")
+        submesh.export(str(visual_dir / f"{segment_name}.stl"))
+        submesh.convex_hull.export(str(collision_dir / f"{segment_name}.stl"))
+
+    def _segment_mesh_from_groups(
+        self,
+        mesh: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        params: BodyParameters | None = None,
+        vertex_groups: dict[str, list[int]] | None = None,
+    ) -> GeneratedMeshResult:
+        """Segment an already loaded MakeHuman mesh by groups or geometry."""
+        del params
+        if vertex_groups:
+            mesh_paths, collision_paths = self._segment_by_vertex_groups(
+                mesh,
+                visual_dir,
+                collision_dir,
+                vertex_groups,
+                MAKEHUMAN_SEGMENT_GROUPS,
+                valid_segments(),
+            )
+        else:
+            mesh_paths, collision_paths = self._segment_by_geometry(
+                mesh, visual_dir, collision_dir, valid_segments()
+            )
+        return GeneratedMeshResult(
+            success=bool(mesh_paths),
+            mesh_paths=mesh_paths,
+            collision_paths=collision_paths,
+            vertex_groups=vertex_groups or {},
+            metadata={"backend": "makehuman"},
+        )
+
+    @staticmethod
+    def _segment_by_vertex_groups(
+        mesh: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        vertex_groups: dict[str, list[int]],
+        group_mapping: dict[str, str],
+        valid_segments: Any,
+    ) -> tuple[dict[str, Path], dict[str, Path]]:
+        """Segment mesh using vertex group indices from an OBJ export."""
+        mesh_paths: dict[str, Path] = {}
+        collision_paths: dict[str, Path] = {}
+        for group_name, vertex_indices in vertex_groups.items():
+            segment_name = group_mapping.get(group_name.lower())
+            if segment_name is None or segment_name not in valid_segments:
+                continue
+            export_submesh(
+                mesh, vertex_indices, segment_name, visual_dir, collision_dir
+            )
+            mesh_paths[segment_name] = visual_dir / f"{segment_name}.stl"
+            collision_paths[segment_name] = collision_dir / f"{segment_name}.stl"
+        return mesh_paths, collision_paths
+
+    @staticmethod
+    def _segment_by_geometry(
+        mesh: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        valid_segments: Any,
+    ) -> tuple[dict[str, Path], dict[str, Path]]:
+        """Segment mesh using bounding-box z-range slicing."""
+        mesh_paths: dict[str, Path] = {}
+        collision_paths: dict[str, Path] = {}
+        for segment_name, z_low in segment_z_ranges().items():
+            if segment_name not in valid_segments:
+                continue
+            submesh = slice_mesh_at_z(mesh, z_low)
+            if submesh is None:
+                continue
+            export_mesh_pair(submesh, segment_name, visual_dir, collision_dir)
+            mesh_paths[segment_name] = visual_dir / f"{segment_name}.stl"
+            collision_paths[segment_name] = collision_dir / f"{segment_name}.stl"
+        return mesh_paths, collision_paths
+
+    def _parse_obj_vertex_groups(self, obj_file: Path) -> dict[str, list[int]]:
+        """Parse OBJ vertex groups as group name to vertex-index mapping."""
+        groups: dict[str, list[int]] = {}
+        current_group = "default"
+        vertex_index = 0
+        with open(obj_file, encoding="utf-8") as fh:
+            for raw_line in fh:
+                current_group, vertex_index = parse_group_line(
+                    raw_line, groups, current_group, vertex_index
+                )
+        return groups
+
+    def get_supported_segments(self) -> list[str]:
+        """Return MakeHuman vertex group names supported by this backend."""
+        return list(self.MH_VERTEX_GROUP_MAP.keys())
+
+    @staticmethod
+    def _convert_params_to_makehuman(params: BodyParameters) -> dict[str, float]:
+        """Convert body parameters to MakeHuman modifier values."""
+        return {
+            "__height_scale__": params.height_m / MAKEHUMAN_DEFAULT_HEIGHT_M,
+            "macrodetails/Gender": params.get_effective_gender_factor(),
+            "macrodetails/Age": clamp(params.appearance.age_years / 80.0, 0.0, 1.0),
+            "macrodetails-universal/Muscle": float(params.muscularity),
+            "macrodetails-universal/Weight": float(params.body_fat_factor),
+            "macrodetails-proportions/BodyProportions": float(
+                params.torso_length_factor - 1.0
+            ),
+            "macrodetails-proportions/ShoulderWidth": float(
+                params.shoulder_width_factor - 1.0
+            ),
+            "macrodetails-proportions/HipWidth": float(params.hip_width_factor - 1.0),
+            "macrodetails-proportions/ArmLength": float(params.arm_length_factor - 1.0),
+            "macrodetails-proportions/LegLength": float(params.leg_length_factor - 1.0),
+        }
+
+    @staticmethod
+    def _parse_obj_file(obj_file: Path) -> tuple[np.ndarray, np.ndarray]:
+        """Parse a Wavefront OBJ file into vertex and triangular face arrays."""
+        vertices_raw: list[list[float]] = []
+        faces_raw: list[list[int]] = []
+        with open(obj_file, encoding="utf-8") as fh:
+            for raw_line in fh:
+                parse_obj_line(raw_line, vertices_raw, faces_raw)
+        return arrays_from_obj_parts(vertices_raw, faces_raw)
+
+    @staticmethod
+    def _build_mh_script(
+        modifiers: dict[str, float],
+        body_obj_path: Path,
+        groups_json_path: Path,
+    ) -> str:
+        """Build a MakeHuman Python script for headless OBJ export."""
+        modifiers_repr = repr(modifiers)
+        obj_path_str = str(body_obj_path).replace("\\", "/")
+        json_path_str = str(groups_json_path).replace("\\", "/")
+        return f"""# Auto-generated MakeHuman scripted-mode script
+import mh
+import human as mh_human
+import json
+
+def exportOBJ(h, path):
+    \"\"\"Minimal OBJ export shim.\"\"\"
+    with open(path, 'w') as fh:
+        for v in h.mesh.coord:
+            fh.write(f'v {{v[0]:.6f}} {{v[1]:.6f}} {{v[2]:.6f}}\\n')
+        for f in h.mesh.fvert:
+            fh.write('f ' + ' '.join(str(i + 1) for i in f) + '\\n')
+
+def generate_human():
+    h = mh_human.human
+    modifiers = {modifiers_repr}
+    for key, value in modifiers.items():
+        if key.startswith('__') and key.endswith('__'):
+            continue
+        try:
+            h.setDetail(key, value)
+        except Exception as exc:  # noqa: BLE001
+            __import__('sys').stderr.write(f'Warning: modifier {{key}}={{value}}: {{exc}}\\n')
+    exportOBJ(h, '{obj_path_str}')
+    groups = {{seg: list(range(10)) for seg in ['head', 'torso', 'pelvis']}}
+    with open('{json_path_str}', 'w') as fh:
+        json.dump(groups, fh)
+
+generate_human()
+"""
+
+    @classmethod
+    def _write_makehuman_script(
+        cls,
+        tmp: Path,
+        modifiers: dict[str, float],
+        body_obj: Path,
+        groups_json: Path,
+    ) -> Path:
+        """Write a temporary MakeHuman script and return its path."""
+        script_path = tmp / "mh_generate.py"
+        script = cls._build_mh_script(modifiers, body_obj, groups_json)
+        script_path.write_text(script, encoding="utf-8")
+        return script_path
+
+    @staticmethod
+    def _run_makehuman_script(script_path: Path, timeout: int = 120) -> bool:
+        """Run a generated MakeHuman script with a bounded timeout."""
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["python", str(script_path)],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("MakeHuman script execution error: %s", exc)
+            return False
+        if result.returncode != 0:
+            logger.warning("MakeHuman script failed: %s", result.stderr[:500])
+            return False
+        return True

--- a/src/shared/python/humanoid_character_builder/generators/makehuman_mesh_utils.py
+++ b/src/shared/python/humanoid_character_builder/generators/makehuman_mesh_utils.py
@@ -1,0 +1,207 @@
+"""MakeHuman mesh parsing and export helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from humanoid_character_builder.generators.mesh_invariants import (
+    validate_mesh_invariants,
+)
+
+logger = logging.getLogger(__name__)
+
+MAKEHUMAN_DEFAULT_HEIGHT_M = 1.68
+MAKEHUMAN_SEARCH_PATHS = (
+    Path("/usr/share/makehuman"),
+    Path.home() / "makehuman",
+    Path.home() / ".makehuman",
+)
+MAKEHUMAN_SEGMENT_GROUPS: dict[str, str] = {
+    "head": "head",
+    "neck": "neck",
+    "torso": "torso",
+    "upper_torso": "torso",
+    "lower_torso": "pelvis",
+    "pelvis": "pelvis",
+    "left_upper_arm": "left_upper_arm",
+    "right_upper_arm": "right_upper_arm",
+    "left_forearm": "left_forearm",
+    "right_forearm": "right_forearm",
+    "left_hand": "left_hand",
+    "right_hand": "right_hand",
+    "left_thigh": "left_thigh",
+    "right_thigh": "right_thigh",
+    "left_shin": "left_shin",
+    "right_shin": "right_shin",
+    "left_foot": "left_foot",
+    "right_foot": "right_foot",
+}
+
+
+def prepare_output_dirs(output_dir: Path) -> tuple[Path, Path]:
+    """Create and return visual/collision output directories."""
+    output_dir = Path(output_dir)
+    visual_dir = output_dir / "visual"
+    collision_dir = output_dir / "collision"
+    visual_dir.mkdir(parents=True, exist_ok=True)
+    collision_dir.mkdir(parents=True, exist_ok=True)
+    return visual_dir, collision_dir
+
+
+def script_outputs(tmp: Path) -> tuple[Path, Path]:
+    """Return the expected temporary MakeHuman OBJ and group JSON paths."""
+    return tmp / "body.obj", tmp / "groups.json"
+
+
+def load_vertex_groups(groups_json: Path) -> dict[str, list[int]]:
+    """Load MakeHuman vertex groups from JSON when available."""
+    if not groups_json.exists():
+        return {}
+    with open(groups_json, encoding="utf-8") as fh:
+        loaded = json.load(fh)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def segment_by_index_range(
+    vertices: np.ndarray,
+    faces: np.ndarray,
+    indices: list[int],
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Extract a segment using the smallest contiguous vertex range."""
+    if not indices:
+        return None
+    in_range = (faces >= min(indices)) & (faces <= max(indices))
+    segment_faces_global = faces[in_range.all(axis=1)]
+    if len(segment_faces_global) == 0:
+        return None
+    unique_vertices, inverse = np.unique(segment_faces_global, return_inverse=True)
+    return vertices[unique_vertices], inverse.reshape(-1, 3)
+
+
+def valid_segments() -> Any:
+    """Return canonical humanoid segment definitions."""
+    from humanoid_character_builder.core.segment_definitions import HUMANOID_SEGMENTS
+
+    return HUMANOID_SEGMENTS
+
+
+def export_submesh(
+    mesh: Any,
+    vertex_indices: list[int],
+    segment_name: str,
+    visual_dir: Path,
+    collision_dir: Path,
+) -> None:
+    """Export a submesh selected by vertex indices."""
+    try:
+        face_mask = mesh.faces_sparse.rows[vertex_indices].indices
+        submesh = mesh.submesh([face_mask], append=True)
+        export_mesh_pair(submesh, segment_name, visual_dir, collision_dir)
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.warning("Failed to extract %s: %s", segment_name, exc)
+
+
+def export_mesh_pair(
+    mesh: Any,
+    segment_name: str,
+    visual_dir: Path,
+    collision_dir: Path,
+) -> None:
+    """Validate and export visual and convex-hull collision meshes."""
+    validate_mesh_invariants(mesh, context=f"MakeHuman {segment_name}")
+    mesh.export(str(visual_dir / f"{segment_name}.stl"))
+    mesh.convex_hull.export(str(collision_dir / f"{segment_name}.stl"))
+
+
+def slice_mesh_at_z(mesh: Any, z_low: float) -> Any | None:
+    """Slice a mesh by normalized z coordinate."""
+    bounds = mesh.bounds
+    height = bounds[1][2] - bounds[0][2]
+    z_min = bounds[0][2] + z_low * height
+    try:
+        submesh = mesh.slice_plane([0, 0, z_min], [0, 0, 1])
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.warning("Failed to slice mesh at z=%s: %s", z_min, exc)
+        return None
+    return submesh if submesh and len(submesh.vertices) > 0 else None
+
+
+def segment_z_ranges() -> dict[str, float]:
+    """Return normalized z cut points for geometry-only segmentation."""
+    return {
+        "head": 0.90,
+        "neck": 0.85,
+        "torso": 0.55,
+        "pelvis": 0.45,
+        "left_thigh": 0.25,
+        "right_thigh": 0.25,
+        "left_shin": 0.08,
+        "right_shin": 0.08,
+        "left_foot": 0.0,
+        "right_foot": 0.0,
+    }
+
+
+def parse_group_line(
+    raw_line: str,
+    groups: dict[str, list[int]],
+    current_group: str,
+    vertex_index: int,
+) -> tuple[str, int]:
+    """Update OBJ vertex-group parser state for one line."""
+    line = raw_line.strip()
+    if line.startswith("g "):
+        group_name = line[2:].strip()
+        groups.setdefault(group_name, [])
+        return group_name, vertex_index
+    if line.startswith("v "):
+        groups.setdefault(current_group, []).append(vertex_index)
+        return current_group, vertex_index + 1
+    return current_group, vertex_index
+
+
+def parse_obj_line(
+    raw_line: str,
+    vertices: list[list[float]],
+    faces: list[list[int]],
+) -> None:
+    """Parse one OBJ vertex or face line into mutable collections."""
+    line = raw_line.strip()
+    if line.startswith("v "):
+        parts = line.split()
+        vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
+    elif line.startswith("f "):
+        append_obj_faces(line.split()[1:], faces)
+
+
+def append_obj_faces(parts: list[str], faces: list[list[int]]) -> None:
+    """Append one OBJ face, triangulating polygons by fan."""
+    indices = [int(part.split("/")[0]) - 1 for part in parts]
+    if len(indices) == 3:
+        faces.append(indices)
+        return
+    for index in range(1, len(indices) - 1):
+        faces.append([indices[0], indices[index], indices[index + 1]])
+
+
+def arrays_from_obj_parts(
+    vertices: list[list[float]],
+    faces: list[list[int]],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Convert parsed OBJ lists into shaped numpy arrays."""
+    vertex_array = (
+        np.array(vertices, dtype=np.float64) if vertices else np.zeros((0, 3))
+    )
+    face_array = (
+        np.array(faces, dtype=np.int64) if faces else np.zeros((0, 3), dtype=np.int64)
+    )
+    return vertex_array, face_array
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp a float to a closed interval."""
+    return float(min(maximum, max(minimum, value)))

--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
@@ -1,10 +1,4 @@
-"""
-Mesh generation interfaces for humanoid character builder.
-
-This module defines interfaces for mesh generation backends
-(MakeHuman, SMPL, etc.) and provides a factory for creating
-mesh generators.
-"""
+"""Shared mesh-generation contracts and backend factory."""
 
 from __future__ import annotations
 
@@ -15,15 +9,12 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from humanoid_character_builder.core.body_parameters import BodyParameters
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Optional dependency availability flags (mock-patchable in tests)
-# ---------------------------------------------------------------------------
-
+# Optional dependency availability flags are intentionally kept here so tests
+# and downstream callers can continue to monkeypatch the historic import path.
 try:
     import smplx as _smplx_module  # type: ignore[import-untyped]
 
@@ -44,45 +35,27 @@ except ImportError:
 class MeshGeneratorBackend(Enum):
     """Available mesh generation backends."""
 
-    PRIMITIVE = "primitive"  # Generate primitive shapes (built-in)
-    MAKEHUMAN = "makehuman"  # MakeHuman integration
-    SMPLX = "smplx"  # SMPL-X body model
-    CUSTOM = "custom"  # Custom mesh provider
+    PRIMITIVE = "primitive"
+    MAKEHUMAN = "makehuman"
+    SMPLX = "smplx"
+    CUSTOM = "custom"
 
 
 @dataclass
 class GeneratedMeshResult:
     """Result of mesh generation."""
 
-    # Whether generation was successful
     success: bool
-
-    # Path to generated mesh files (segment name -> path)
     mesh_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Path to collision mesh files
     collision_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Path to texture files
     texture_paths: dict[str, Path] = field(default_factory=dict)
-
-    # Vertex group mapping (for segmentation)
     vertex_groups: dict[str, list[int]] = field(default_factory=dict)
-
-    # Error message if failed
     error_message: str | None = None
-
-    # Additional metadata
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class MeshGeneratorInterface(ABC):
-    """
-    Abstract interface for mesh generation backends.
-
-    Implement this interface to add new mesh generation sources
-    (MakeHuman, SMPL, etc.).
-    """
+    """Abstract interface for mesh generation backends."""
 
     @property
     @abstractmethod
@@ -93,7 +66,7 @@ class MeshGeneratorInterface(ABC):
     @property
     @abstractmethod
     def is_available(self) -> bool:
-        """Check if the backend is available (installed, configured)."""
+        """Return whether the backend is installed and configured."""
         ...
 
     @abstractmethod
@@ -103,710 +76,28 @@ class MeshGeneratorInterface(ABC):
         output_dir: Path,
         **kwargs: Any,
     ) -> GeneratedMeshResult:
-        """
-        Generate meshes for the given body parameters.
-
-        Args:
-            params: Body parameters
-            output_dir: Directory to write mesh files
-            **kwargs: Backend-specific options
-
-        Returns:
-            GeneratedMeshResult with paths to generated files
-        """
+        """Generate meshes for the given body parameters."""
         ...
 
     @abstractmethod
     def get_supported_segments(self) -> list[str]:
-        """Return list of segment names this backend can generate."""
+        """Return segment names this backend can generate."""
         ...
 
 
-# ---------------------------------------------------------------------------
-# Primitive backend (extracted to primitive_mesh_generator.py as part of #136).
-# Re-exported here for backward compatibility with existing imports.
-# ---------------------------------------------------------------------------
+from humanoid_character_builder.generators.makehuman_mesh_generator import (  # noqa: E402
+    MakeHumanMeshGenerator,
+)
 from humanoid_character_builder.generators.primitive_mesh_generator import (  # noqa: E402
     PrimitiveMeshGenerator,
 )
-
-
-class MakeHumanMeshGenerator(MeshGeneratorInterface):
-    """
-    Generate meshes using MakeHuman.
-
-    This is a placeholder for future MakeHuman integration.
-    MakeHuman provides high-quality, customizable human meshes
-    with proper vertex groups for segmentation.
-    """
-
-    def __init__(self, makehuman_path: Path | str | None = None):
-        """
-        Initialize MakeHuman generator.
-
-        Args:
-            makehuman_path: Path to MakeHuman installation
-        """
-        self.makehuman_path = Path(makehuman_path) if makehuman_path else None
-
-    @property
-    def backend_name(self) -> str:
-        return "makehuman"
-
-    @property
-    def is_available(self) -> bool:
-        # Check if MakeHuman is installed
-        if self.makehuman_path and self.makehuman_path.exists():
-            return True
-
-        # Try to find MakeHuman in common locations
-        common_paths = [
-            Path("/usr/share/makehuman"),
-            Path.home() / "makehuman",
-            Path.home() / ".makehuman",
-        ]
-        for path in common_paths:
-            if path.exists():
-                self.makehuman_path = path
-                return True
-
-        return False
-
-    def generate(
-        self,
-        params: BodyParameters,
-        output_dir: Path,
-        **kwargs: Any,
-    ) -> GeneratedMeshResult:
-        """Generate meshes using MakeHuman.
-
-        Uses MakeHuman's Python API when available, or falls back to
-        loading pre-made MakeHuman exports with vertex group segmentation.
-        """
-        assert params is not None, "params must be provided"
-        assert params is not None, "params must be provided"
-        if not self.is_available:
-            return GeneratedMeshResult(
-                success=False,
-                error_message="MakeHuman not found. Please install MakeHuman or provide path.",
-            )
-
-        output_dir = Path(output_dir)
-        visual_dir = output_dir / "visual"
-        collision_dir = output_dir / "collision"
-        visual_dir.mkdir(parents=True, exist_ok=True)
-        collision_dir.mkdir(parents=True, exist_ok=True)
-
-        modifiers = self._convert_params_to_makehuman(params)
-
-        # Try the scripted MakeHuman API
-        try:
-            return self._generate_via_api(
-                params, modifiers, visual_dir, collision_dir, **kwargs
-            )
-        except (
-            ValueError,
-            ZeroDivisionError,
-            OverflowError,
-            TypeError,
-            RuntimeError,
-        ) as e:
-            logger.warning("MakeHuman API generation failed: %s", e)
-            return GeneratedMeshResult(
-                success=False,
-                error_message=f"MakeHuman generation failed: {e}",
-            )
-
-    def _generate_via_api(
-        self,
-        params: BodyParameters,
-        modifiers: dict[str, float],
-        visual_dir: Path,
-        collision_dir: Path,
-        **kwargs: Any,
-    ) -> GeneratedMeshResult:
-        """Generate meshes using MakeHuman scripted mode.
-
-        Writes a Python script via _build_mh_script and runs it via
-        _run_makehuman_script, then loads the resulting OBJ and segments it.
-        """
-        assert params is not None, "params must be provided"
-        assert params is not None, "params must be provided"
-        import json
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp = Path(tmpdir)
-            script_path = tmp / "mh_generate.py"
-            body_obj = tmp / "body.obj"
-            groups_json = tmp / "groups.json"
-
-            script_content = self._build_mh_script(modifiers, body_obj, groups_json)
-            script_path.write_text(script_content, encoding="utf-8")
-
-            success = self._run_makehuman_script(script_path)
-            if not success:
-                raise RuntimeError("MakeHuman script execution failed")
-
-            if not body_obj.exists():
-                raise RuntimeError(f"MakeHuman did not produce OBJ: {body_obj}")
-
-            # Load vertex groups if available
-            vertex_groups: dict[str, list[int]] = {}
-            if groups_json.exists():
-                with open(groups_json, encoding="utf-8") as fh:
-                    vertex_groups = json.load(fh)
-
-            # Parse OBJ
-            vertices, faces = self._parse_obj_file(body_obj)
-            if len(vertices) == 0:
-                raise RuntimeError("Parsed OBJ has no vertices")
-
-            # Segment the mesh and export per-body-part STLs
-            if not TRIMESH_AVAILABLE:
-                raise RuntimeError("trimesh required for mesh segmentation")
-
-            mesh = _trimesh_module.Trimesh(vertices=vertices, faces=faces)  # type: ignore[union-attr]
-
-            from humanoid_character_builder.core.segment_definitions import (
-                HUMANOID_SEGMENTS,
-            )
-
-            mesh_paths: dict[str, Path] = {}
-            collision_paths: dict[str, Path] = {}
-
-            all_vertices = (
-                np.array(mesh.vertices) if hasattr(mesh, "vertices") else vertices
-            )
-            all_faces = np.array(mesh.faces) if hasattr(mesh, "faces") else faces
-
-            for mh_group, segment_name in self.MH_VERTEX_GROUP_MAP.items():
-                if segment_name not in HUMANOID_SEGMENTS:
-                    continue
-                indices = vertex_groups.get(mh_group, [])
-                if not indices:
-                    continue
-                try:
-                    seg_verts, seg_faces = SMPLXMeshGenerator._segment_mesh(
-                        all_vertices,
-                        all_faces,
-                        min(indices),
-                        max(indices) + 1,
-                    )
-                    if len(seg_verts) == 0:
-                        continue
-                    submesh = _trimesh_module.Trimesh(  # type: ignore[union-attr]
-                        vertices=seg_verts, faces=seg_faces
-                    )
-                    vpath = visual_dir / f"{segment_name}.stl"
-                    submesh.export(str(vpath))
-                    mesh_paths[segment_name] = vpath
-                    cpath = collision_dir / f"{segment_name}.stl"
-                    submesh.convex_hull.export(str(cpath))
-                    collision_paths[segment_name] = cpath
-                except (
-                    AttributeError,
-                    ValueError,
-                    ZeroDivisionError,
-                    OverflowError,
-                    TypeError,
-                ) as exc:
-                    logger.warning("Failed to segment %s: %s", segment_name, exc)
-
-        return GeneratedMeshResult(
-            success=len(mesh_paths) > 0,
-            mesh_paths=mesh_paths,
-            collision_paths=collision_paths,
-            vertex_groups=vertex_groups,
-            metadata={"backend": "makehuman"},
-        )
-
-    def _generate_from_presets(
-        self,
-        params: BodyParameters,
-        visual_dir: Path,
-        collision_dir: Path,
-        **kwargs: Any,
-    ) -> GeneratedMeshResult:
-        """Load pre-exported MakeHuman mesh based on parameters."""
-        try:
-            import trimesh
-        except ImportError as err:
-            raise RuntimeError("trimesh required for mesh processing") from err
-
-        # Look for pre-exported mesh files in MakeHuman data directory
-        if self.makehuman_path is None:
-            raise RuntimeError("MakeHuman path not configured")
-        presets_dir = self.makehuman_path / "data" / "exports"
-        if not presets_dir.exists():
-            presets_dir = self.makehuman_path / "exports"
-
-        # Select preset based on build type
-        preset_name = params.build_type or "average"
-        gender = "male" if params.get_effective_gender_factor() > 0.5 else "female"
-        preset_file = presets_dir / f"{gender}_{preset_name}.obj"
-
-        if not preset_file.exists():
-            # Try default
-            preset_file = presets_dir / f"{gender}_average.obj"
-
-        if not preset_file.exists():
-            raise FileNotFoundError(f"No MakeHuman preset found: {preset_file}")
-
-        # Load and segment the mesh
-        mesh = trimesh.load(str(preset_file))
-
-        # Scale to target height
-        current_height = mesh.bounds[1][2] - mesh.bounds[0][2]
-        scale_factor = params.height_m / current_height
-        mesh.apply_scale(scale_factor)
-
-        return self._segment_mesh_from_groups(mesh, visual_dir, collision_dir, params)
-
-    def _segment_mesh(
-        self, visual_dir: Path, collision_dir: Path
-    ) -> GeneratedMeshResult:
-        """Segment a generated mesh by vertex groups."""
-        assert visual_dir is not None, "visual_dir must be provided"
-        assert visual_dir is not None, "visual_dir must be provided"
-        try:
-            import trimesh
-        except ImportError as err:
-            raise RuntimeError("trimesh required for mesh segmentation") from err
-
-        obj_file = visual_dir / "humanoid.obj"
-        if not obj_file.exists():
-            raise FileNotFoundError(f"Generated mesh not found: {obj_file}")
-
-        mesh = trimesh.load(str(obj_file))
-
-        # Get vertex groups from OBJ file
-        vertex_groups = self._parse_obj_vertex_groups(obj_file)
-
-        return self._segment_mesh_from_groups(
-            mesh, visual_dir, collision_dir, vertex_groups=vertex_groups
-        )
-
-    def _segment_mesh_from_groups(
-        self,
-        mesh: Any,
-        visual_dir: Path,
-        collision_dir: Path,
-        params: BodyParameters | None = None,
-        vertex_groups: dict[str, list[int]] | None = None,
-    ) -> GeneratedMeshResult:
-        """Segment mesh into body parts using vertex groups or geometry."""
-        assert visual_dir is not None, "visual_dir must be provided"
-        assert visual_dir is not None, "visual_dir must be provided"
-        from humanoid_character_builder.core.segment_definitions import (
-            HUMANOID_SEGMENTS,
-        )
-
-        # Map MakeHuman vertex groups to our segment names
-        group_mapping = {
-            "head": "head",
-            "neck": "neck",
-            "torso": "torso",
-            "upper_torso": "torso",
-            "lower_torso": "pelvis",
-            "pelvis": "pelvis",
-            "left_upper_arm": "left_upper_arm",
-            "right_upper_arm": "right_upper_arm",
-            "left_forearm": "left_forearm",
-            "right_forearm": "right_forearm",
-            "left_hand": "left_hand",
-            "right_hand": "right_hand",
-            "left_thigh": "left_thigh",
-            "right_thigh": "right_thigh",
-            "left_shin": "left_shin",
-            "right_shin": "right_shin",
-            "left_foot": "left_foot",
-            "right_foot": "right_foot",
-        }
-
-        if vertex_groups:
-            mesh_paths, collision_paths = self._segment_by_vertex_groups(
-                mesh,
-                visual_dir,
-                collision_dir,
-                vertex_groups,
-                group_mapping,
-                HUMANOID_SEGMENTS,
-            )
-        else:
-            mesh_paths, collision_paths = self._segment_by_geometry(
-                mesh,
-                visual_dir,
-                collision_dir,
-                HUMANOID_SEGMENTS,
-            )
-
-        return GeneratedMeshResult(
-            success=len(mesh_paths) > 0,
-            mesh_paths=mesh_paths,
-            collision_paths=collision_paths,
-            vertex_groups=vertex_groups or {},
-            metadata={"backend": "makehuman"},
-        )
-
-    @staticmethod
-    def _segment_by_vertex_groups(
-        mesh: Any,
-        visual_dir: Path,
-        collision_dir: Path,
-        vertex_groups: dict[str, list[int]],
-        group_mapping: dict[str, str],
-        valid_segments: Any,
-    ) -> tuple[dict[str, Path], dict[str, Path]]:
-        """Segment mesh using vertex group indices."""
-        assert visual_dir is not None, "visual_dir must be provided"
-        assert visual_dir is not None, "visual_dir must be provided"
-        mesh_paths: dict[str, Path] = {}
-        collision_paths: dict[str, Path] = {}
-
-        for group_name, vertex_indices in vertex_groups.items():
-            segment_name = group_mapping.get(group_name.lower())
-            if segment_name and segment_name in valid_segments:
-                try:
-                    face_mask = mesh.faces_sparse.rows[vertex_indices].indices
-                    submesh = mesh.submesh([face_mask], append=True)
-
-                    visual_path = visual_dir / f"{segment_name}.stl"
-                    submesh.export(str(visual_path))
-                    mesh_paths[segment_name] = visual_path
-
-                    collision_mesh = submesh.convex_hull
-                    collision_path = collision_dir / f"{segment_name}.stl"
-                    collision_mesh.export(str(collision_path))
-                    collision_paths[segment_name] = collision_path
-                except (
-                    ValueError,
-                    ZeroDivisionError,
-                    OverflowError,
-                    TypeError,
-                ) as e:
-                    logger.warning(f"Failed to extract {segment_name}: {e}")
-
-        return mesh_paths, collision_paths
-
-    @staticmethod
-    def _segment_by_geometry(
-        mesh: Any,
-        visual_dir: Path,
-        collision_dir: Path,
-        valid_segments: Any,
-    ) -> tuple[dict[str, Path], dict[str, Path]]:
-        """Segment mesh using bounding-box z-range slicing."""
-        assert visual_dir is not None, "visual_dir must be provided"
-        assert visual_dir is not None, "visual_dir must be provided"
-        mesh_paths: dict[str, Path] = {}
-        collision_paths: dict[str, Path] = {}
-
-        bounds = mesh.bounds
-        height = bounds[1][2] - bounds[0][2]
-
-        segment_z_ranges = {
-            "head": (0.90, 1.0),
-            "neck": (0.85, 0.90),
-            "torso": (0.55, 0.85),
-            "pelvis": (0.45, 0.55),
-            "left_thigh": (0.25, 0.45),
-            "right_thigh": (0.25, 0.45),
-            "left_shin": (0.08, 0.25),
-            "right_shin": (0.08, 0.25),
-            "left_foot": (0.0, 0.08),
-            "right_foot": (0.0, 0.08),
-        }
-
-        for segment_name, (z_low, _z_high) in segment_z_ranges.items():
-            if segment_name in valid_segments:
-                z_min = bounds[0][2] + z_low * height
-
-                try:
-                    plane_origin = [0, 0, z_min]
-                    plane_normal = [0, 0, 1]
-                    submesh = mesh.slice_plane(plane_origin, plane_normal)
-
-                    if submesh and len(submesh.vertices) > 0:
-                        visual_path = visual_dir / f"{segment_name}.stl"
-                        submesh.export(str(visual_path))
-                        mesh_paths[segment_name] = visual_path
-
-                        collision_path = collision_dir / f"{segment_name}.stl"
-                        submesh.convex_hull.export(str(collision_path))
-                        collision_paths[segment_name] = collision_path
-                except (
-                    ValueError,
-                    ZeroDivisionError,
-                    OverflowError,
-                    TypeError,
-                ) as e:
-                    logger.warning(f"Failed to slice {segment_name}: {e}")
-
-        return mesh_paths, collision_paths
-
-    def _parse_obj_vertex_groups(self, obj_file: Path) -> dict[str, list[int]]:
-        """Parse vertex groups from OBJ file."""
-        assert obj_file is not None, "obj_file must be provided"
-        assert obj_file is not None, "obj_file must be provided"
-        groups: dict[str, list[int]] = {}
-        current_group = "default"
-        vertex_index = 0
-
-        with open(obj_file) as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("g "):
-                    current_group = line[2:].strip()
-                    if current_group not in groups:
-                        groups[current_group] = []
-                elif line.startswith("v "):
-                    if current_group not in groups:
-                        groups[current_group] = []
-                    groups[current_group].append(vertex_index)
-                    vertex_index += 1
-
-        return groups
-
-    def get_supported_segments(self) -> list[str]:
-        """Return unique segment names from MH_VERTEX_GROUP_MAP."""
-        return list(self.MH_VERTEX_GROUP_MAP.keys())
-
-    @staticmethod
-    def _convert_params_to_makehuman(params: BodyParameters) -> dict[str, float]:
-        """Convert BodyParameters to MakeHuman modifier values.
-
-        MakeHuman uses modifiers in range [-1, 1] or [0, 1].
-        `__height_scale__` is a private sentinel used by the generate pipeline
-        to scale the skeleton; it's not a native MakeHuman key.
-        """
-        modifiers: dict[str, float] = {}
-
-        # Height: MakeHuman default human is ~1.68 m.
-        # Store scale factor so generate() can apply an overall body-size offset.
-        makehuman_default_height_m = 1.68
-        modifiers["__height_scale__"] = params.height_m / makehuman_default_height_m
-
-        # Gender (MakeHuman: 0 = female, 1 = male)
-        modifiers["macrodetails/Gender"] = params.get_effective_gender_factor()
-
-        # Age (MakeHuman: [0, 1] where 0 = child, 1 = elderly)
-        modifiers["macrodetails/Age"] = float(
-            min(1.0, max(0.0, params.appearance.age_years / 80.0))
-        )
-
-        # Muscularity (MakeHuman: [0, 1] muscle definition)
-        modifiers["macrodetails-universal/Muscle"] = float(params.muscularity)
-
-        # Weight / body fat ([0, 1])
-        modifiers["macrodetails-universal/Weight"] = float(params.body_fat_factor)
-
-        # Proportions — map factor deltas to [-1, 1] MakeHuman modifier range
-        modifiers["macrodetails-proportions/BodyProportions"] = float(
-            params.torso_length_factor - 1.0
-        )
-        modifiers["macrodetails-proportions/ShoulderWidth"] = float(
-            params.shoulder_width_factor - 1.0
-        )
-        modifiers["macrodetails-proportions/HipWidth"] = float(
-            params.hip_width_factor - 1.0
-        )
-        modifiers["macrodetails-proportions/ArmLength"] = float(
-            params.arm_length_factor - 1.0
-        )
-        modifiers["macrodetails-proportions/LegLength"] = float(
-            params.leg_length_factor - 1.0
-        )
-
-        return modifiers
-
-    # ------------------------------------------------------------------
-    # Static helpers (testable without a full generate() run)
-    # ------------------------------------------------------------------
-
-    #: Mapping from MakeHuman vertex group names → our segment names.
-    #: Each key AND each value must be unique (bijective mapping).
-    MH_VERTEX_GROUP_MAP: dict[str, str] = {
-        "head": "head",
-        "neck": "neck",
-        "torso": "torso",
-        "pelvis": "pelvis",
-        "left_upper_arm": "left_upper_arm",
-        "right_upper_arm": "right_upper_arm",
-        "left_forearm": "left_forearm",
-        "right_forearm": "right_forearm",
-        "left_hand": "left_hand",
-        "right_hand": "right_hand",
-        "left_thigh": "left_thigh",
-        "right_thigh": "right_thigh",
-        "left_shin": "left_shin",
-        "right_shin": "right_shin",
-        "left_foot": "left_foot",
-        "right_foot": "right_foot",
-    }
-
-    @staticmethod
-    def _parse_obj_file(obj_file: Path) -> tuple[np.ndarray, np.ndarray]:
-        """Parse a Wavefront OBJ file into numpy arrays.
-
-        Handles:
-        - Vertex declarations (``v x y z``)
-        - Triangle faces (``f i j k``)
-        - Quad faces (``f i j k l``) — fan-triangulated
-        - Face refs with normals/texcoords (``f i/t/n ...``) — vertex index only
-
-        Args:
-            obj_file: Path to the .obj file.
-
-        Returns:
-            Tuple of (vertices, faces) where:
-            - vertices: float64 array of shape (N, 3)
-            - faces: int64 array of shape (M, 3), 0-indexed
-        """
-        vertices_raw: list[list[float]] = []
-        faces_raw: list[list[int]] = []
-
-        with open(obj_file, encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if line.startswith("v "):
-                    parts = line.split()
-                    vertices_raw.append(
-                        [float(parts[1]), float(parts[2]), float(parts[3])]
-                    )
-                elif line.startswith("f "):
-                    parts = line.split()[1:]
-                    # Handle face refs like "1/2/3" — extract vertex index only
-                    indices = [int(p.split("/")[0]) - 1 for p in parts]
-                    if len(indices) == 3:
-                        faces_raw.append(indices)
-                    elif len(indices) >= 4:
-                        # Fan triangulate
-                        for k in range(1, len(indices) - 1):
-                            faces_raw.append([indices[0], indices[k], indices[k + 1]])
-
-        vertices = (
-            np.array(vertices_raw, dtype=np.float64)
-            if vertices_raw
-            else np.zeros((0, 3))
-        )
-        faces = (
-            np.array(faces_raw, dtype=np.int64)
-            if faces_raw
-            else np.zeros((0, 3), dtype=np.int64)
-        )
-        return vertices, faces
-
-    @staticmethod
-    def _build_mh_script(
-        modifiers: dict[str, float],
-        body_obj_path: Path,
-        groups_json_path: Path,
-    ) -> str:
-        """Build a MakeHuman Python script for headless mesh export.
-
-        The generated script applies the given modifiers to the human model,
-        exports the body as an OBJ file, and writes vertex group assignments
-        as a JSON file so we can segment the mesh later.
-
-        Args:
-            modifiers: MakeHuman modifier name → value mapping.
-            body_obj_path: Destination OBJ path for the exported body.
-            groups_json_path: Destination JSON path for vertex groups.
-
-        Returns:
-            Python source code string ready to be written to a .py file.
-        """
-        assert modifiers is not None, "modifiers must be provided"
-        assert modifiers is not None, "modifiers must be provided"
-        modifiers_repr = repr(modifiers)
-        obj_path_str = str(body_obj_path).replace("\\", "/")
-        json_path_str = str(groups_json_path).replace("\\", "/")
-        return f"""# Auto-generated MakeHuman scripted-mode script
-import mh
-import human as mh_human
-import json
-
-def exportOBJ(h, path):
-    \"\"\"Minimal OBJ export shim.\"\"\"
-    with open(path, 'w') as fh:
-        for v in h.mesh.coord:
-            fh.write(f'v {{v[0]:.6f}} {{v[1]:.6f}} {{v[2]:.6f}}\\n')
-        for f in h.mesh.fvert:
-            fh.write('f ' + ' '.join(str(i + 1) for i in f) + '\\n')
-
-def generate_human():
-    h = mh_human.human
-
-    modifiers = {modifiers_repr}
-    # Strip private sentinels before applying to MakeHuman
-    for key, value in modifiers.items():
-        if key.startswith('__') and key.endswith('__'):
-            continue
-        try:
-            h.setDetail(key, value)
-        except Exception as exc:  # noqa: BLE001
-            __import__('sys').stderr.write(f'Warning: modifier {{key}}={{value}}: {{exc}}\\n')
-
-    exportOBJ(h, '{obj_path_str}')
-
-    groups = {{seg: list(range(10)) for seg in ['head', 'torso', 'pelvis']}}
-    import json
-    with open('{json_path_str}', 'w') as fh:
-        json.dump(groups, fh)
-
-generate_human()
-"""  # noqa: E501
-
-    @staticmethod
-    def _run_makehuman_script(
-        script_path: Path,
-        timeout: int = 120,
-    ) -> bool:
-        """Run a MakeHuman Python script via subprocess.
-
-        Args:
-            script_path: Path to the .py script to execute.
-            timeout: Maximum seconds to wait.
-
-        Returns:
-            True if the script exited with return code 0, False otherwise.
-        """
-        assert script_path is not None, "script_path must be provided"
-        assert script_path is not None, "script_path must be provided"
-        import subprocess
-
-        try:
-            result = subprocess.run(
-                ["python", str(script_path)],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            if result.returncode != 0:
-                logger.warning("MakeHuman script failed: %s", result.stderr[:500])
-                return False
-            return True
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            logger.warning("MakeHuman script execution error: %s", exc)
-            return False
-
-
-# ---------------------------------------------------------------------------
-# SMPL-X backend (extracted to smplx_mesh_generator.py as part of #136).
-# Re-exported here for backward compatibility with existing imports.
-# ---------------------------------------------------------------------------
 from humanoid_character_builder.generators.smplx_mesh_generator import (  # noqa: E402
     SMPLXMeshGenerator,
 )
 
 
 class MeshGenerator:
-    """
-    Factory class for creating mesh generators.
-
-    Provides a unified interface to multiple mesh generation backends.
-    """
+    """Factory class for creating mesh generators."""
 
     _generators: dict[MeshGeneratorBackend, type[MeshGeneratorInterface]] = {
         MeshGeneratorBackend.PRIMITIVE: PrimitiveMeshGenerator,
@@ -820,59 +111,69 @@ class MeshGenerator:
         backend: MeshGeneratorBackend | str = MeshGeneratorBackend.PRIMITIVE,
         **kwargs: Any,
     ) -> MeshGeneratorInterface:
-        """
-        Create a mesh generator for the specified backend.
-
-        Args:
-            backend: Backend to use
-            **kwargs: Backend-specific initialization options
-
-        Returns:
-            MeshGeneratorInterface instance
-        """
-        if isinstance(backend, str):
-            backend = MeshGeneratorBackend(backend.lower())
-
-        generator_class = cls._generators.get(backend)
+        """Create a mesh generator for the specified backend."""
+        normalized_backend = _normalize_backend(backend)
+        generator_class = cls._generators.get(normalized_backend)
         if generator_class is None:
-            raise ValueError(f"Unknown backend: {backend}")
-
+            raise ValueError(f"Unknown backend: {normalized_backend}")
         return generator_class(**kwargs)
 
     @classmethod
     def get_available_backends(cls) -> list[MeshGeneratorBackend]:
-        """Return list of available backends."""
-        available = []
+        """Return backends whose dependencies and configuration are present."""
+        available: list[MeshGeneratorBackend] = []
         for backend, generator_class in cls._generators.items():
-            try:
-                generator = generator_class()
-                if generator.is_available:
-                    available.append(backend)
-            except (ImportError, RuntimeError, OSError) as e:
-                logger.debug("Backend %s not available: %s", backend.value, e)
+            if _backend_is_available(backend, generator_class):
+                available.append(backend)
         return available
 
     @classmethod
     def get_best_available(cls) -> MeshGeneratorInterface:
-        """
-        Get the best available mesh generator.
-
-        Preference order: MakeHuman > SMPL-X > Primitive
-        """
-        preference = [
-            MeshGeneratorBackend.MAKEHUMAN,
-            MeshGeneratorBackend.SMPLX,
-            MeshGeneratorBackend.PRIMITIVE,
-        ]
-
-        for backend in preference:
+        """Return the preferred available backend."""
+        for backend in _backend_preference():
             try:
                 generator = cls.create(backend)
-                if generator.is_available:
-                    return generator
-            except (ImportError, RuntimeError, OSError) as e:
-                logger.debug("Backend %s not available: %s", backend.value, e)
+            except (ImportError, RuntimeError, OSError) as exc:
+                logger.debug("Backend %s not available: %s", backend.value, exc)
                 continue
-
-        # Final fallback
+            if generator.is_available:
+                return generator
         return PrimitiveMeshGenerator()
+
+
+def _normalize_backend(backend: MeshGeneratorBackend | str) -> MeshGeneratorBackend:
+    if isinstance(backend, str):
+        return MeshGeneratorBackend(backend.lower())
+    return backend
+
+
+def _backend_is_available(
+    backend: MeshGeneratorBackend,
+    generator_class: type[MeshGeneratorInterface],
+) -> bool:
+    try:
+        return generator_class().is_available
+    except (ImportError, RuntimeError, OSError) as exc:
+        logger.debug("Backend %s not available: %s", backend.value, exc)
+        return False
+
+
+def _backend_preference() -> tuple[MeshGeneratorBackend, ...]:
+    return (
+        MeshGeneratorBackend.MAKEHUMAN,
+        MeshGeneratorBackend.SMPLX,
+        MeshGeneratorBackend.PRIMITIVE,
+    )
+
+
+__all__ = [
+    "GeneratedMeshResult",
+    "MakeHumanMeshGenerator",
+    "MeshGenerator",
+    "MeshGeneratorBackend",
+    "MeshGeneratorInterface",
+    "PrimitiveMeshGenerator",
+    "SMPLXMeshGenerator",
+    "SMPLX_AVAILABLE",
+    "TRIMESH_AVAILABLE",
+]

--- a/src/shared/python/humanoid_character_builder/generators/mesh_invariants.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_invariants.py
@@ -1,0 +1,93 @@
+"""Mesh invariant checks shared by humanoid mesh generators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MeshInvariantPolicy:
+    """Controls which generated mesh invariants are enforced."""
+
+    require_manifold: bool = False
+    require_no_self_intersections: bool = True
+
+
+DEFAULT_SEGMENT_POLICY = MeshInvariantPolicy()
+
+
+def validate_mesh_invariants(
+    mesh: Any,
+    *,
+    context: str,
+    policy: MeshInvariantPolicy = DEFAULT_SEGMENT_POLICY,
+) -> None:
+    """Validate mesh invariants before export.
+
+    Preconditions:
+        mesh exposes finite vertices and triangular faces when those
+        attributes are available.
+
+    Postconditions:
+        Detectable manifold and self-intersection invariants are honored
+        according to *policy*.
+    """
+    if mesh is None:
+        raise ValueError(f"{context}: mesh must be provided")
+    _validate_vertices(mesh, context)
+    _validate_faces(mesh, context)
+    _validate_manifold(mesh, context, policy)
+    _validate_self_intersection(mesh, context, policy)
+
+
+def _validate_vertices(mesh: Any, context: str) -> None:
+    vertices = getattr(mesh, "vertices", None)
+    if vertices is None:
+        return
+    vertices_arr = np.asarray(vertices)
+    if vertices_arr.size == 0:
+        raise ValueError(f"{context}: mesh has no vertices")
+    if vertices_arr.ndim != 2 or vertices_arr.shape[1] != 3:
+        raise ValueError(f"{context}: vertices must have shape (N, 3)")
+    if not np.isfinite(vertices_arr).all():
+        raise ValueError(f"{context}: vertices must be finite")
+
+
+def _validate_faces(mesh: Any, context: str) -> None:
+    faces = getattr(mesh, "faces", None)
+    vertices = getattr(mesh, "vertices", None)
+    if faces is None or vertices is None:
+        return
+    faces_arr = np.asarray(faces)
+    if faces_arr.size == 0:
+        raise ValueError(f"{context}: mesh has no faces")
+    if faces_arr.ndim != 2 or faces_arr.shape[1] != 3:
+        raise ValueError(f"{context}: faces must have shape (M, 3)")
+    vertex_count = len(vertices)
+    if faces_arr.min() < 0 or faces_arr.max() >= vertex_count:
+        raise ValueError(f"{context}: face indices are outside vertex range")
+
+
+def _validate_manifold(
+    mesh: Any,
+    context: str,
+    policy: MeshInvariantPolicy,
+) -> None:
+    is_watertight = getattr(mesh, "is_watertight", None)
+    if policy.require_manifold and is_watertight is False:
+        raise ValueError(f"{context}: mesh must be manifold/watertight")
+
+
+def _validate_self_intersection(
+    mesh: Any,
+    context: str,
+    policy: MeshInvariantPolicy,
+) -> None:
+    if not policy.require_no_self_intersections:
+        return
+    intersects = getattr(mesh, "is_self_intersecting", None)
+    if intersects is True:
+        raise ValueError(f"{context}: mesh must not self-intersect")

--- a/tests/unit/tools/humanoid_character_builder/test_makehuman_mesh_generator.py
+++ b/tests/unit/tools/humanoid_character_builder/test_makehuman_mesh_generator.py
@@ -1,0 +1,148 @@
+"""Unit tests for the extracted MakeHumanMeshGenerator."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from humanoid_character_builder.core.body_parameters import BodyParameters
+from humanoid_character_builder.generators.makehuman_mesh_generator import (
+    MakeHumanMeshGenerator,
+)
+from humanoid_character_builder.generators.mesh_generator import (
+    MakeHumanMeshGenerator as ReexportedMakeHuman,
+)
+
+
+def _default_params(**overrides: Any) -> BodyParameters:
+    kwargs: dict[str, Any] = {"height_m": 1.80, "mass_kg": 80.0}
+    kwargs.update(overrides)
+    return BodyParameters(**kwargs)
+
+
+class TestMakeHumanMeshGeneratorContract:
+    """Static properties of the extracted backend."""
+
+    def test_backend_name_is_makehuman(self) -> None:
+        assert MakeHumanMeshGenerator().backend_name == "makehuman"
+
+    def test_reexport_is_same_class(self) -> None:
+        assert ReexportedMakeHuman is MakeHumanMeshGenerator
+
+    def test_supported_segments_match_vertex_group_map(self) -> None:
+        segments = MakeHumanMeshGenerator().get_supported_segments()
+        assert len(segments) == len(MakeHumanMeshGenerator.MH_VERTEX_GROUP_MAP)
+        assert "head" in segments
+        assert "right_foot" in segments
+
+
+class TestMakeHumanMeshGeneratorAvailability:
+    """Availability behavior should remain compatible with the old module."""
+
+    def test_unavailable_when_path_missing(self) -> None:
+        gen = MakeHumanMeshGenerator(makehuman_path="/definitely/missing")
+        assert gen.is_available is False
+
+    def test_available_when_path_exists(self, tmp_path: Path) -> None:
+        gen = MakeHumanMeshGenerator(makehuman_path=tmp_path)
+        assert gen.is_available is True
+
+
+class TestMakeHumanMeshGeneratorParsing:
+    """Static OBJ helpers should keep existing behavior after extraction."""
+
+    def test_parse_obj_with_quad_triangulation(self, tmp_path: Path) -> None:
+        obj_file = tmp_path / "body.obj"
+        obj_file.write_text(
+            textwrap.dedent("""\
+                v 0.0 0.0 0.0
+                v 1.0 0.0 0.0
+                v 1.0 1.0 0.0
+                v 0.0 1.0 0.0
+                f 1 2 3 4
+                """),
+            encoding="utf-8",
+        )
+
+        vertices, faces = MakeHumanMeshGenerator._parse_obj_file(obj_file)
+
+        assert vertices.shape == (4, 3)
+        assert faces.shape == (2, 3)
+
+    def test_script_contains_expected_makehuman_operations(self) -> None:
+        script = MakeHumanMeshGenerator._build_mh_script(
+            {"macrodetails/Gender": 1.0},
+            Path("body.obj"),
+            Path("groups.json"),
+        )
+        assert "macrodetails/Gender" in script
+        assert "exportOBJ" in script
+        assert "json.dump" in script
+
+
+class TestMakeHumanMeshGeneratorGenerate:
+    """Exercise the generate path with subprocess and trimesh mocked."""
+
+    def test_generate_rejects_none_params(self, tmp_path: Path) -> None:
+        gen = MakeHumanMeshGenerator(makehuman_path=tmp_path)
+        with pytest.raises(AssertionError):
+            gen.generate(None, tmp_path / "out")  # type: ignore[arg-type]
+
+    @patch(
+        "humanoid_character_builder.generators.mesh_generator.TRIMESH_AVAILABLE", True
+    )
+    @patch("humanoid_character_builder.generators.mesh_generator._trimesh_module")
+    def test_generate_happy_path_with_mocks(
+        self,
+        mock_trimesh: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        gen = MakeHumanMeshGenerator(makehuman_path=tmp_path)
+        mock_trimesh.Trimesh = _fake_trimesh_factory()
+
+        def mock_run(script_path: Path, timeout: int = 120) -> bool:
+            del timeout
+            script_dir = script_path.parent
+            _write_grouped_obj(script_dir / "body.obj")
+            (script_dir / "groups.json").write_text(
+                json.dumps({"head": [0, 1, 2]}),
+                encoding="utf-8",
+            )
+            return True
+
+        with patch.object(gen, "_run_makehuman_script", side_effect=mock_run):
+            result = gen.generate(_default_params(), tmp_path / "out")
+
+        assert result.success is True
+        assert result.metadata["backend"] == "makehuman"
+        assert result.mesh_paths["head"].suffix == ".stl"
+        assert (tmp_path / "out" / "visual").is_dir()
+        assert (tmp_path / "out" / "collision").is_dir()
+
+
+def _fake_trimesh_factory() -> type:
+    class FakeTrimesh:
+        def __init__(self, vertices: Any = None, faces: Any = None) -> None:
+            self.vertices = vertices
+            self.faces = faces
+
+        def export(self, path: str) -> None:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            Path(path).touch()
+
+        @property
+        def convex_hull(self) -> FakeTrimesh:
+            return self
+
+    return FakeTrimesh
+
+
+def _write_grouped_obj(obj_file: Path) -> None:
+    obj_file.write_text(
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n",
+        encoding="utf-8",
+    )

--- a/tests/unit/tools/humanoid_character_builder/test_mesh_invariants.py
+++ b/tests/unit/tools/humanoid_character_builder/test_mesh_invariants.py
@@ -1,0 +1,60 @@
+"""Unit tests for shared generated-mesh invariant checks."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from humanoid_character_builder.generators.mesh_invariants import (
+    MeshInvariantPolicy,
+    validate_mesh_invariants,
+)
+
+
+class _FakeMesh:
+    def __init__(
+        self,
+        *,
+        vertices: np.ndarray,
+        faces: np.ndarray,
+        is_watertight: bool = True,
+        is_self_intersecting: bool = False,
+    ) -> None:
+        self.vertices = vertices
+        self.faces = faces
+        self.is_watertight = is_watertight
+        self.is_self_intersecting = is_self_intersecting
+
+
+def test_valid_mesh_passes_default_policy() -> None:
+    mesh = _FakeMesh(
+        vertices=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        faces=np.array([[0, 1, 2]]),
+    )
+
+    validate_mesh_invariants(mesh, context="unit")
+
+
+def test_self_intersection_is_rejected() -> None:
+    mesh = _FakeMesh(
+        vertices=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        faces=np.array([[0, 1, 2]]),
+        is_self_intersecting=True,
+    )
+
+    with pytest.raises(ValueError, match="self-intersect"):
+        validate_mesh_invariants(mesh, context="unit")
+
+
+def test_manifold_policy_rejects_open_mesh() -> None:
+    mesh = _FakeMesh(
+        vertices=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        faces=np.array([[0, 1, 2]]),
+        is_watertight=False,
+    )
+
+    with pytest.raises(ValueError, match="manifold"):
+        validate_mesh_invariants(
+            mesh,
+            context="unit",
+            policy=MeshInvariantPolicy(require_manifold=True),
+        )


### PR DESCRIPTION
## Summary
- extract MakeHuman mesh generation out of `mesh_generator.py` into a focused backend module
- keep `mesh_generator.py` as shared contracts, compatibility re-exports, availability flags, and factory dispatch
- add shared generated-mesh invariant checks for vertices, faces, optional manifold policy, and self-intersection signals
- add focused tests for MakeHuman extraction and mesh invariant contracts

Closes #136

## Validation
- `python -m ruff check .`
- `python -m black --check src/shared/python/humanoid_character_builder/generators/mesh_generator.py src/shared/python/humanoid_character_builder/generators/makehuman_mesh_generator.py src/shared/python/humanoid_character_builder/generators/makehuman_mesh_utils.py src/shared/python/humanoid_character_builder/generators/mesh_invariants.py tests/unit/tools/humanoid_character_builder/test_makehuman_mesh_generator.py tests/unit/tools/humanoid_character_builder/test_mesh_invariants.py`
- `python -m mypy src/shared/python/humanoid_character_builder/generators/mesh_generator.py src/shared/python/humanoid_character_builder/generators/makehuman_mesh_generator.py src/shared/python/humanoid_character_builder/generators/makehuman_mesh_utils.py src/shared/python/humanoid_character_builder/generators/mesh_invariants.py`
- `python scripts/check_function_size_budget.py --changed --base-ref origin/main`
- `python -m pytest tests/unit/tools/humanoid_character_builder/test_mesh_invariants.py tests/unit/tools/humanoid_character_builder/test_makehuman_mesh_generator.py tests/unit/tools/humanoid_character_builder/test_smplx_mesh_generator.py tests/unit/tools/humanoid_character_builder/test_primitive_mesh_generator.py tests/unit/tools/humanoid_character_builder/test_mesh_generators.py`