### PR TITLE
refactor(#142): decompose 7 oversized functions via Extract Method

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | Primary Language(s) | Python 3.10+, Rust, TypeScript, MATLAB |
 | License | MIT |
 | Current Version | `2.1.0` |
-| Spec Version | `1.0.15` |
+| Spec Version | `1.0.16` |
 | Last Spec Update | `2026-04-16` |
 
 ## 2. Purpose
@@ -130,6 +130,7 @@ The repository is organized around a Python application core with multiple front
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-16 | 1.0.16 | Decomposed 7 oversized functions (issue #142) using Extract Method: `optimize_swing`, `generate` (collision_generator), `_add_live_kinematics_overlays`, `run_adam_optimization`, `calculate_flare_size`, `compute_jacobian`, and `_generate_via_api`. All target functions now under 50 LOC with private helper methods extracted; public interfaces unchanged. |
 | 2026-04-16 | 1.0.15 | Excluded Jupyter notebooks from T201 ruff lint rule (print is standard display in notebooks); decomposed `PhysicsValidator.validate_inertia_tensor` (101 LOC) into `_check_symmetry`, `_check_eigenvalues`, and `_check_triangle_inequality` helpers (partial fix for #142 and #150). |
 | 2026-04-15 | 1.0.14 | Marked the advanced putting-green simulator scenarios as slow so stochastic multi-ball scatter simulations stay out of the default core CI lane while lighter putting-green coverage remains active. |
 | 2026-04-15 | 1.0.13 | Hardened the cross-engine validator CI step with the same Xvfb plugin disable flags and serial pytest execution used by the core Python lane, preventing worker-level Xvfb startup failures after the main suite passes. |


### PR DESCRIPTION
## Summary

- Decomposes all 7 functions listed in issue #142 using the Extract Method pattern, bringing each under the 50-LOC CI budget enforced by `scripts/check_function_size_budget.py --include src`
- `optimize_swing` → delegates to `_validate_initial_state`, `_run_optimization_loop`, `_evaluate_trajectory`
- `generate` (collision_generator) → delegates to `_resolve_generate_parameters`, `_dispatch_generation`, `_build_success_result`, `_build_error_result`
- `_add_live_kinematics_overlays` → delegates to `_overlay_euler`, `_overlay_quat`, `_overlay_screw`
- `run_adam_optimization` → delegates to `_init_adam_state`, `_run_adam_loop`, `_build_optimization_results`
- `calculate_flare_size` → delegates to `_normalize_composition`, `_compute_mixture_properties`, `_compute_gas_density`, `_compute_flare_diameter`, `_compute_flare_height`
- `compute_jacobian` → delegates to `_jacobian_finite_diff`, `_restore_q`
- `_generate_via_api` → delegates to `_load_body_mesh`, `_export_grouped_segments`, `_export_segment`
- Bumps SPEC.md from `1.0.15` to `1.0.16` with changelog entry
- All public interfaces unchanged; pure structural refactor

## Test plan

- [ ] `python scripts/check_function_size_budget.py --include src` reports `OK: all functions are within the 50-line budget.`
- [ ] `ruff check src/ --select E,F,I,W` passes (only pre-existing E501 lines, which are ignored per pyproject.toml)
- [ ] `ruff format src/ --check` reports all files already formatted
- [ ] SPEC.md version `1.0.16` is strictly greater than main's `1.0.15`
- [ ] Existing test suite passes (no logic changed)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)