### PR TITLE
feat: raise coverage threshold to 50% (closes #143)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 | Primary Language(s) | Python 3.10+, Rust, TypeScript, MATLAB |
 | License | MIT |
 | Current Version | `2.1.0` |
-| Spec Version | `1.0.17` |
+| Spec Version | `1.0.18` |
 | Last Spec Update | `2026-04-16` |
 
 ## 2. Purpose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,8 +324,8 @@ omit = [
 
 [tool.coverage.report]
 # Coverage threshold — enforced in CI and locally when running with --cov.
-# Set to 45% (actual measured: ~46%) per issue #97; target remains 60% (#1630).
-fail_under = 45
+# Raised to 50% per issue #143 (was 45%); target remains 60% (#1630).
+fail_under = 50
 show_missing = true
 skip_empty = true
 precision = 1


### PR DESCRIPTION
## Summary
- Raise `fail_under` in `[tool.coverage.report]` from 45% → 50%
- Bump SPEC.md to 1.0.18 (from 1.0.17)
- The new tests from PR #185 (pressure_drop extracted helpers, 47 test cases) provide sufficient coverage to cross this threshold

Closes #143

## Test plan
- [ ] CI quality-gate passes with the new threshold
- [ ] Coverage report shows ≥ 50% overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)