### PR TITLE
fix(docker): add missing pandas/matplotlib runtime deps + smoke-test server import

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -75,3 +75,12 @@ jobs:
           docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy; print('Core physics stack OK')"
           docker run --rm upstream-drift:runtime python -c "import fastapi, uvicorn; print('API server stack OK')"
           docker run --rm upstream-drift:runtime python -c "import pinocchio; print('Pinocchio OK')"
+
+      - name: Verify API server imports end-to-end
+        # Catches cases where individual packages import fine but the actual
+        # server module fails (e.g. missing pandas/matplotlib coming from the
+        # old conda base). A green import here means `CMD uvicorn ...` will
+        # also boot, instead of crashing at runtime and never being noticed
+        # because nobody runs the image past `docker build`.
+        run: |
+          docker run --rm upstream-drift:runtime python -c "from src.api import server; print('server import OK')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,16 @@ RUN pip install \
     structlog>=24.1.0 \
     colorama>=0.4.6
 
+# Shared-code runtime deps imported at module top-level by
+# src/shared/python (pandas, matplotlib, sympy) and API routes that parse
+# XML (defusedxml). These used to come from the conda base; keep them
+# explicit for the slim build so the API import chain actually resolves.
+RUN pip install \
+    "pandas>=2.0.0" \
+    "matplotlib>=3.7.0" \
+    "sympy>=1.12" \
+    "defusedxml>=0.7.1"
+
 # Pinocchio via pip (binary wheels available since 2024 — no conda needed)
 RUN pip install \
     pin \


### PR DESCRIPTION
The slim Dockerfile shipped in b8348af9 produces an image whose CMD (uvicorn) crashes: pandas missing from the conda-removed runtime. Adds pandas/matplotlib/sympy/defusedxml (previously from conda base) and extends smoke test to verify `from src.api import server` boots. Verified locally: 3.18 GB, /health returns engines_available=8. See D-sorganization/UpstreamDrift#2793 for the full fleet-wide analysis and dashboard lazy-import fix (not needed here — Golf dashboard/__init__.py is already empty).