### PR TITLE
fix: Docker runtime API smoke tests and port alignment (#207)

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -75,3 +75,41 @@ jobs:
           docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy, pandas, matplotlib, sympy, defusedxml; print('Core physics and analysis stack OK')"
           docker run --rm upstream-drift:runtime python -c "import fastapi, uvicorn; print('API server stack OK')"
           docker run --rm upstream-drift:runtime python -c "import pinocchio; print('Pinocchio OK')"
+
+      - name: Verify API Server Import
+        run: |
+          docker run --rm upstream-drift:runtime python -c "from src.api import server; print('API server module import OK')"
+
+      - name: Verify API Health Endpoint
+        run: |
+          # Start the API server in detached mode, forwarding port 8000
+          CID=$(docker run -d -p 8000:8000 \
+            -e API_HOST=0.0.0.0 \
+            -e ENVIRONMENT=development \
+            upstream-drift:runtime \
+            python -c "
+          import uvicorn
+          from src.api.server import app
+          uvicorn.run(app, host='0.0.0.0', port=8000, log_level='warning')
+          ")
+          echo "Container ID: $CID"
+
+          # Wait for the server to become ready (up to 30 s)
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "Health endpoint responded on attempt $i"
+              break
+            fi
+            sleep 1
+          done
+
+          # Assert the endpoint returns HTTP 200
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health)
+          docker stop "$CID" || true
+
+          echo "HTTP status: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::/health returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "/health endpoint smoke test passed."

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,10 +88,10 @@ COPY --chown=${USER_NAME}:${USER_NAME} .env.example ./.env.example
 
 USER ${USER_NAME}
 
-EXPOSE 8001
+EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8001/health || exit 1
+    CMD curl -f http://localhost:8000/health || exit 1
 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
## Summary

- Adds a `from src.api import server` import verification step to the Docker size-gates workflow, confirming the API module loads cleanly in the slim runtime image.
- Adds a `/health` endpoint smoke test: starts the server in a detached container with `API_HOST=0.0.0.0`, polls up to 30 seconds for readiness, asserts HTTP 200, then stops the container.
- Fixes a port mismatch in the Dockerfile: `EXPOSE` and `HEALTHCHECK` both used port 8001 while the API default (`API_PORT`) is 8000 — now both are aligned to 8000.

Closes #207

## Test plan

- [ ] `docker-size-gates` workflow passes on merge to main
- [ ] `Verify API Server Import` step exits 0
- [ ] `Verify API Health Endpoint` step exits 0 with HTTP 200
- [ ] `quality-gate` and other required checks pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)