### PR TITLE
fix(docker): include boot deps + API smoke test (#207)

### DIFF
--- a/.github/workflows/docker-size-gates.yml
+++ b/.github/workflows/docker-size-gates.yml
@@ -75,3 +75,25 @@ jobs:
           docker run --rm upstream-drift:runtime python -c "import mujoco, numpy, scipy, pandas, matplotlib, sympy, defusedxml; print('Core physics and analysis stack OK')"
           docker run --rm upstream-drift:runtime python -c "import fastapi, uvicorn; print('API server stack OK')"
           docker run --rm upstream-drift:runtime python -c "import pinocchio; print('Pinocchio OK')"
+          docker run --rm upstream-drift:runtime python -c "from src.api import server; print('src.api.server import OK')"
+
+      - name: Verify /health endpoint
+        run: |
+          # Launch the API server in the built image and probe /health.
+          CID=$(docker run -d -p 8001:8001 upstream-drift:runtime \
+            python -m uvicorn src.api.server:app --host 0.0.0.0 --port 8001)
+          echo "Container: $CID"
+          # Poll /health for up to 30s
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8001/health >/dev/null 2>&1; then
+              echo "/health responded on attempt $i"
+              docker logs "$CID" | tail -20 || true
+              docker rm -f "$CID" >/dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::/health did not respond within 30s"
+          docker logs "$CID" || true
+          docker rm -f "$CID" >/dev/null || true
+          exit 1


### PR DESCRIPTION
Closes #207.

Boot-critical runtime deps (pandas, matplotlib, sympy, defusedxml) already landed via PR #208, and the Docker smoke step already imports them. This extends `.github/workflows/docker-size-gates.yml` to satisfy the remaining acceptance criteria from issue #207:

- adds `from src.api import server` smoke import on the built runtime image
- launches uvicorn inside the runtime container and probes `/health` (30s poll) to confirm the API actually boots

Fleet old-issue triage — wave 32.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>